### PR TITLE
web.rs: fix invalid location header

### DIFF
--- a/src/entrypoint/web.rs
+++ b/src/entrypoint/web.rs
@@ -70,7 +70,7 @@ async fn force_https(req: http::Request<Incoming>) -> anyhow::Result<Response> {
 
     Ok(http::Response::builder()
         .status(StatusCode::MOVED_PERMANENTLY)
-        .header("localtion", uri)
+        .header("location", uri)
         .body(empty())
         .expect("body should never fail"))
 }


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Redirect URI field in 3xx should be 'Location' as defined in https://datatracker.ietf.org/doc/html/rfc2616#section-14.30