### PR TITLE
fix(entrypoint): Update Content-Length header to correct size

### DIFF
--- a/src/entrypoint.rs
+++ b/src/entrypoint.rs
@@ -553,7 +553,10 @@ fn serve_sdk(path: &str) -> anyhow::Result<Response> {
     }
 }
 
-fn build_response(parts: http::response::Parts, body: Bytes) -> Response {
+fn build_response(mut parts: http::response::Parts, body: Bytes) -> Response {
+    // Update Content-Length header to correct size
+    parts.headers.insert("content-length", body.len());
+
     let mut builder = http::Response::builder();
     for (name, value) in parts.headers {
         if name.is_some() {


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The `Content-Length` header was not updated when returning the modified response, which lead to failed a "sanity check" in `hyper` when building in debug mode.

The fix is located on the `build_response` function by modifying the `http::HeaderMap` of the response parts (using `insert` which actually *replace* the name-value pair instead of appending it, as headers are multi-valued with some exceptions)
