### PR TITLE
chore: changed uszie to HeaderValue

### DIFF
--- a/src/entrypoint.rs
+++ b/src/entrypoint.rs
@@ -555,7 +555,7 @@ fn serve_sdk(path: &str) -> anyhow::Result<Response> {
 
 fn build_response(mut parts: http::response::Parts, body: Bytes) -> Response {
     // Update Content-Length header to correct size
-    parts.headers.insert("content-length", body.len());
+    parts.headers.insert("content-length", body.len().into());
 
     let mut builder = http::Response::builder();
     for (name, value) in parts.headers {


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Changed this from
https://github.com/edgee-cloud/edgee/blob/e3ccb3a1431087528e8cb5b17da5a610a62d5652/src/entrypoint.rs#L558

To
`parts.headers.insert("content-length", body.len().into());`

### Related Issues

Expected HeaderValue, found usize https://github.com/edgee-cloud/edgee/issues/37
