### PR TITLE
chore: remove unused flake publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,22 +3,6 @@ on:
   release:
     types: [published]
 jobs:
-  flakehub:
-    name: "Publish to Flakehub"
-    runs-on: "ubuntu-latest"
-    permissions:
-      id-token: "write"
-      contents: "read"
-    steps:
-      - uses: "actions/checkout@v4"
-        with:
-          ref: "${{ github.ref_name }}"
-      - uses: "DeterminateSystems/nix-installer-action@main"
-      - uses: "DeterminateSystems/flakehub-push@main"
-        with:
-          visibility: "public"
-          name: "edgee-cloud/edgee"
-          tag: "${{ github.ref_name }}"
   cratesio:
     name: Publish to Crates.io
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Remove GitHub flake publishing action. It's not useful for now

### Related Issues
No issue
