### PR TITLE
feat: option to enforce no-store cache policy

### DIFF
--- a/edgee.sample.toml
+++ b/edgee.sample.toml
@@ -2,16 +2,20 @@
 level = "info"
 
 [http]
-address = "0.0.0.0:8080"
+address = "0.0.0.0:80"
 force_https = true
 
 [https]
-address = "0.0.0.0:8443"
+address = "0.0.0.0:443"
 cert = "local/cert/edgee.pem"
 key = "local/cert/edgee.key"
 
 [monitor]
 address = "0.0.0.0:8222"
+
+[compute]
+proxy_only = false
+enforce_no_store_policy = true
 
 [[components.data_collection]]
 name = "amplitude"
@@ -35,5 +39,5 @@ domain = "demo.edgee.dev"
 [[routing.backends]]
 name = "demo"
 default = true
-address = "localhost:9000"
+address = "localhost:8080"
 enable_ssl = false

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -41,6 +41,7 @@ fn default_compute_config() -> ComputeConfiguration {
         max_decompressed_body_size: default_max_decompressed_body_size(),
         max_compressed_body_size: default_max_compressed_body_size(),
         proxy_only: false,
+        enforce_no_store_policy: false,
         data_collection_api_key: None,
         data_collection_api_url: None,
     }
@@ -176,6 +177,8 @@ pub struct ComputeConfiguration {
     pub max_compressed_body_size: usize,
     #[serde(default)]
     pub proxy_only: bool,
+    #[serde(default)]
+    pub enforce_no_store_policy: bool,
     pub data_collection_api_key: Option<String>,
     pub data_collection_api_url: Option<String>,
 }


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

To maximize Edgee’s efficiency, it is best to ensure that computed content is not cacheable by browsers or shared caches.
However, upstream servers may add cache-control directives that are difficult to modify or remove.
In such cases, you can override the cache-control directive with a no-store policy to prevent content from being cached.

### Related Issues

#74 
