### PR TITLE
Cargo test fails occasionally when running all tests

### DIFF
--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -1,9 +1,9 @@
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use tokio::sync::OnceCell;
+use std::sync::OnceLock;
 
-static CONFIG: OnceCell<StaticConfiguration> = OnceCell::const_new();
+static CONFIG: OnceLock<StaticConfiguration> = OnceLock::new();
 
 pub trait Validate {
     fn validate(&self) -> Result<(), Vec<String>>;
@@ -249,7 +249,5 @@ pub fn init_test_config() {
         components: ComponentsConfiguration::default(),
     };
 
-    if CONFIG.get().is_none() {
-        CONFIG.set(config).expect("Should initialize config");
-    }
+    CONFIG.get_or_init(|| config);
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Running all the unit tests would fail occasionally (roughly 1 out of 10), either decrypt_failed_decryption or decrypt_valid_text would fail:

(Running on an M1 Macbook pro)

```
...
test tools::real_ip::tests::is_private_address_returns_false_for_public_ip ... ok
test tools::real_ip::tests::is_private_address_returns_true_for_private_ip ... ok
test tools::real_ip::tests::new_realip_initializes_with_private_cidrs ... ok
test tools::crypto::tests::decrypt_valid_text ... FAILED

failures:

---- tools::crypto::tests::decrypt_valid_text stdout ----
thread 'tools::crypto::tests::decrypt_valid_text' panicked at src/config/config.rs:253:28:
Should initialize config: InitializingError(StaticConfiguration { log: LogConfiguration { level: "info" }, http: Some(HttpConfiguration { address: "127.0.0.1:8080", force_https: false }), https: Some(HttpsConfiguration { address: "127.0.0.1:8443", cert: "cert.pem", key: "key.pem" }), compute: ComputeConfiguration { cookie_name: "edgee", aes_key: "_key.edgee.cloud", aes_iv: "__iv.edgee.cloud", behind_proxy_cache: false, max_decompressed_body_size: 6000000, max_compressed_body_size: 3000000, proxy_only: false, enforce_no_store_policy: false, data_collection_api_key: None, data_collection_api_url: None }, monitor: Some(MonitorConfiguration { address: "127.0.0.1:9090" }), routing: [], components: ComponentsConfiguration { data_collection: [] } })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

when investigating further this issue never happened when running a single test, so the fact that cargo test runs all tests concurrently in different threads caused some sort of issue.

The [usage of the tokio OnceCell](https://github.com/edgee-cloud/edgee/blob/037cd546ed856486e10aa0cdd28ca42189032872/src/config/config.rs#L252) is wrong:

It _is_ possible for more than one thread to pass the outer check, and then one of those would fail setting. To fix we need a get_or_init call.

The get_or_init from the tokio version would require that test to be a tokio async tests, in this case using the std version seems better, as we have a race condition between os threads.


### Related Issues

List related issues here
