### PR TITLE
perf(data_collection): Make Data-Collection Component Calls Asynchronous

### DIFF
--- a/src/proxy/compute/data_collection/components.rs
+++ b/src/proxy/compute/data_collection/components.rs
@@ -46,7 +46,7 @@ pub fn init() {
     }
 }
 
-pub async fn send_data_collection(p: &Payload) -> anyhow::Result<()> {
+pub async fn send_data_collection(p: Payload) -> anyhow::Result<()> {
     let engine = WASM_ENGINE.get().unwrap();
     let linker = WASM_LINKER.get().unwrap();
     let mut store = wasmtime::Store::new(engine, HostView::new());

--- a/src/proxy/compute/data_collection/components/context.rs
+++ b/src/proxy/compute/data_collection/components/context.rs
@@ -1,0 +1,102 @@
+use std::collections::HashMap;
+
+use tokio::sync::OnceCell;
+use wasmtime::{
+    component::{Component, InstancePre, Linker, ResourceTable},
+    Engine, Store,
+};
+use wasmtime_wasi::{WasiCtx, WasiView};
+
+use super::DataCollection;
+use crate::config::config;
+
+static COMPONENTS_CONTEXT: OnceCell<ComponentsContext> = OnceCell::const_new();
+
+pub struct ComponentsContext {
+    pub engine: Engine,
+    pub components: HashMap<String, InstancePre<HostState>>,
+}
+
+impl ComponentsContext {
+    fn new() -> anyhow::Result<Self> {
+        let mut engine_config = wasmtime::Config::new();
+        engine_config.wasm_component_model(true);
+
+        let engine = Engine::new(&engine_config)?;
+
+        let mut linker = Linker::new(&engine);
+        wasmtime_wasi::add_to_linker_sync(&mut linker)?;
+
+        let config = config::get();
+        let components = config
+            .components
+            .data_collection
+            .iter()
+            .map(|entry| {
+                let component = Component::from_file(&engine, &entry.component)?;
+                let instance_pre = linker.instantiate_pre(&component)?;
+                Ok((entry.name.clone(), instance_pre))
+            })
+            .collect::<anyhow::Result<_>>()?;
+
+        Ok(Self { engine, components })
+    }
+
+    pub fn init() -> anyhow::Result<()> {
+        let ctx = Self::new()?;
+
+        COMPONENTS_CONTEXT
+            .set(ctx)
+            .map_err(|err| anyhow::anyhow!("Failed to register ComponentsContext: {err}"))
+    }
+
+    pub fn get() -> &'static ComponentsContext {
+        COMPONENTS_CONTEXT
+            .get()
+            .expect("ComponentsContext should be registered")
+    }
+
+    pub fn empty_store(&self) -> Store<HostState> {
+        Store::new(&self.engine, HostState::new())
+    }
+
+    pub async fn instantiate_data_collection(
+        &self,
+        name: &str,
+        store: &mut Store<HostState>,
+    ) -> anyhow::Result<DataCollection> {
+        let instance_pre = self
+            .components
+            .get(name)
+            .expect("Data collection not found, should not happen");
+
+        let (instance, _) = DataCollection::instantiate_pre(store, instance_pre).await?;
+
+        Ok(instance)
+    }
+}
+
+pub struct HostState {
+    ctx: WasiCtx,
+    table: ResourceTable,
+}
+
+impl HostState {
+    fn new() -> Self {
+        let ctx = WasiCtx::builder().build();
+
+        let table = ResourceTable::new();
+
+        Self { ctx, table }
+    }
+}
+
+impl WasiView for HostState {
+    fn ctx(&mut self) -> &mut WasiCtx {
+        &mut self.ctx
+    }
+
+    fn table(&mut self) -> &mut ResourceTable {
+        &mut self.table
+    }
+}

--- a/src/proxy/compute/data_collection/components/context.rs
+++ b/src/proxy/compute/data_collection/components/context.rs
@@ -21,6 +21,7 @@ impl ComponentsContext {
     fn new() -> anyhow::Result<Self> {
         let mut engine_config = wasmtime::Config::new();
         engine_config.wasm_component_model(true);
+        engine_config.async_support(true);
 
         let engine = Engine::new(&engine_config)?;
 

--- a/src/proxy/compute/data_collection/components/convert.rs
+++ b/src/proxy/compute/data_collection/components/convert.rs
@@ -1,0 +1,150 @@
+use std::collections::HashMap;
+
+use super::exports::provider;
+use crate::proxy::compute::data_collection::payload;
+
+impl From<payload::Payload> for provider::Payload {
+    fn from(value: payload::Payload) -> Self {
+        Self {
+            uuid: value.uuid,
+            timestamp: value.timestamp.timestamp(),
+            timestamp_millis: value.timestamp.timestamp_millis(),
+            timestamp_micros: value.timestamp.timestamp_micros(),
+            event_type: value.event_type.unwrap_or_default().into(),
+            page: value.page.unwrap_or_default().into(),
+            identify: value.identify.unwrap_or_default().into(),
+            track: value.track.unwrap_or_default().into(),
+            campaign: value.campaign.unwrap_or_default().into(),
+            client: value.client.unwrap_or_default().into(),
+            session: value.session.unwrap_or_default().into(),
+        }
+    }
+}
+
+impl From<payload::EventType> for provider::EventType {
+    fn from(value: payload::EventType) -> Self {
+        match value {
+            payload::EventType::Page => Self::Page,
+            payload::EventType::Identify => Self::Identify,
+            payload::EventType::Track => Self::Track,
+        }
+    }
+}
+
+impl From<payload::Page> for provider::PageEvent {
+    fn from(value: payload::Page) -> Self {
+        Self {
+            name: value.name.unwrap_or_default(),
+            category: value.category.unwrap_or_default(),
+            keywords: value.keywords.unwrap_or_default(),
+            title: value.title.unwrap_or_default(),
+            url: value.url.unwrap_or_default(),
+            path: value.path.unwrap_or_default(),
+            search: value.search.unwrap_or_default(),
+            referrer: value.referrer.unwrap_or_default(),
+            properties: convert_dict(value.properties.unwrap_or_default()),
+        }
+    }
+}
+
+impl From<payload::Identify> for provider::IdentifyEvent {
+    fn from(value: payload::Identify) -> Self {
+        Self {
+            user_id: value.user_id.unwrap_or_default(),
+            anonymous_id: value.anonymous_id.unwrap_or_default(),
+            edgee_id: value.edgee_id,
+            properties: convert_dict(value.properties.unwrap_or_default()),
+        }
+    }
+}
+
+impl From<payload::Track> for provider::TrackEvent {
+    fn from(value: payload::Track) -> Self {
+        Self {
+            name: value.name.unwrap_or_default(),
+            properties: convert_dict(value.properties.unwrap_or_default()),
+        }
+    }
+}
+
+impl From<payload::Campaign> for provider::Campaign {
+    fn from(value: payload::Campaign) -> Self {
+        Self {
+            name: value.name.unwrap_or_default(),
+            source: value.source.unwrap_or_default(),
+            medium: value.medium.unwrap_or_default(),
+            term: value.term.unwrap_or_default(),
+            content: value.content.unwrap_or_default(),
+            creative_format: value.creative_format.unwrap_or_default(),
+            marketing_tactic: value.marketing_tactic.unwrap_or_default(),
+        }
+    }
+}
+
+impl From<payload::Client> for provider::Client {
+    fn from(value: payload::Client) -> Self {
+        Self {
+            ip: anonymize_ip(&value.ip.unwrap_or_default()),
+            locale: value.locale.unwrap_or_default(),
+            timezone: value.timezone.unwrap_or_default(),
+            user_agent: value.user_agent.unwrap_or_default(),
+            user_agent_architecture: value.user_agent_architecture.unwrap_or_default(),
+            user_agent_bitness: value.user_agent_bitness.unwrap_or_default(),
+            user_agent_full_version_list: value.user_agent_full_version_list.unwrap_or_default(),
+            user_agent_mobile: value.user_agent_mobile.unwrap_or_default(),
+            user_agent_model: value.user_agent_model.unwrap_or_default(),
+            os_name: value.os_name.unwrap_or_default(),
+            os_version: value.os_version.unwrap_or_default(),
+            screen_width: value.screen_width.unwrap_or_default(),
+            screen_height: value.screen_height.unwrap_or_default(),
+            screen_density: value.screen_density.unwrap_or_default(),
+            continent: Default::default(),
+            country_code: Default::default(),
+            country_name: Default::default(),
+            region: Default::default(),
+            city: Default::default(),
+        }
+    }
+}
+
+impl From<payload::Session> for provider::Session {
+    fn from(value: payload::Session) -> Self {
+        Self {
+            session_id: value.session_id,
+            previous_session_id: value.previous_session_id.unwrap_or_default(),
+            session_count: value.session_count,
+            session_start: value.session_start,
+            first_seen: value.first_seen.timestamp(),
+            last_seen: value.last_seen.timestamp(),
+        }
+    }
+}
+
+fn convert_dict<T: ToString>(dict: HashMap<String, T>) -> Vec<(String, String)> {
+    dict.into_iter()
+        .map(|(key, value)| (key, value.to_string()))
+        .collect()
+}
+
+fn anonymize_ip(ip: &str) -> String {
+    use std::net::IpAddr;
+
+    const KEEP_IPV4_BYTES: usize = 3;
+    const KEEP_IPV6_BYTES: usize = 6;
+
+    let ip: IpAddr = ip.parse().unwrap();
+    let anonymized_ip = match ip {
+        IpAddr::V4(ip) => {
+            let mut data = ip.octets();
+            data[KEEP_IPV4_BYTES..].fill(0);
+            IpAddr::V4(data.into())
+        }
+        IpAddr::V6(ip) => {
+            let mut data = ip.octets();
+            data[KEEP_IPV6_BYTES..].fill(0);
+            IpAddr::V6(data.into())
+        }
+    };
+
+    anonymized_ip.to_string()
+}

--- a/src/proxy/compute/data_collection/components/mod.rs
+++ b/src/proxy/compute/data_collection/components/mod.rs
@@ -1,20 +1,22 @@
+use std::str::FromStr;
+use std::time::Duration;
+
+use http::{HeaderMap, HeaderName, HeaderValue};
+use tracing::{error, info};
+
+use crate::config::config;
+use crate::proxy::compute::data_collection::payload::Payload;
+use context::ComponentsContext;
+use exports::provider;
+
+mod context;
+mod convert;
+
 wasmtime::component::bindgen!({
     world: "data-collection",
     path: "wit/protocols.wit",
     async: true,
 });
-
-use crate::config::config;
-use crate::proxy::compute::data_collection::payload::{EventType, Payload};
-use context::ComponentsContext;
-use exports::provider;
-use http::{HeaderMap, HeaderName, HeaderValue};
-use std::net::IpAddr;
-use std::str::FromStr;
-use std::time::Duration;
-use tracing::{error, info};
-
-mod context;
 
 pub fn init() {
     ComponentsContext::init().unwrap();
@@ -23,240 +25,29 @@ pub fn init() {
 pub async fn send_data_collection(p: Payload) -> anyhow::Result<()> {
     let config = config::get();
 
+    // Fail early in case of invalid payload
+    if p.event_type.is_none() {
+        anyhow::bail!("invalid event type");
+    }
+
     let ctx = ComponentsContext::get();
     let mut store = ctx.empty_store();
 
-    // clone the payload to be able to move it to the async thread
-    let payload = provider::Payload {
-        uuid: p.uuid.clone(),
-        timestamp: p.timestamp.timestamp(),
-        timestamp_millis: p.timestamp.timestamp_millis(),
-        timestamp_micros: p.timestamp.timestamp_micros(),
-        event_type: match p.event_type {
-            Some(EventType::Page) => provider::EventType::Page,
-            Some(EventType::Identify) => provider::EventType::Identify,
-            Some(EventType::Track) => provider::EventType::Track,
-            _ => provider::EventType::Page,
-        },
-        page: provider::PageEvent {
-            name: p.page.clone().unwrap_or_default().name.unwrap_or_default(),
-            category: p
-                .page
-                .clone()
-                .unwrap_or_default()
-                .category
-                .unwrap_or_default(),
-            keywords: p
-                .page
-                .clone()
-                .unwrap_or_default()
-                .keywords
-                .unwrap_or_default(),
-            title: p.page.clone().unwrap_or_default().title.unwrap_or_default(),
-            url: p.page.clone().unwrap_or_default().url.unwrap_or_default(),
-            path: p.page.clone().unwrap_or_default().path.unwrap_or_default(),
-            search: p
-                .page
-                .clone()
-                .unwrap_or_default()
-                .search
-                .unwrap_or_default(),
-            referrer: p
-                .page
-                .clone()
-                .unwrap_or_default()
-                .referrer
-                .unwrap_or_default(),
-            properties: p
-                .page
-                .clone()
-                .unwrap_or_default()
-                .properties
-                .unwrap_or_default()
-                .into_iter()
-                .map(|(key, value)| (key, value.to_string()))
-                .collect(),
-        },
-        identify: provider::IdentifyEvent {
-            user_id: p
-                .identify
-                .clone()
-                .unwrap_or_default()
-                .user_id
-                .unwrap_or_default(),
-            anonymous_id: p
-                .identify
-                .clone()
-                .unwrap_or_default()
-                .anonymous_id
-                .unwrap_or_default(),
-            edgee_id: p.identify.clone().unwrap_or_default().edgee_id,
-            properties: p
-                .identify
-                .clone()
-                .unwrap_or_default()
-                .properties
-                .unwrap_or_default()
-                .into_iter()
-                .map(|(key, value)| (key, value.to_string()))
-                .collect(),
-        },
-        track: provider::TrackEvent {
-            name: p.track.clone().unwrap_or_default().name.unwrap_or_default(),
-            properties: p
-                .track
-                .clone()
-                .unwrap_or_default()
-                .properties
-                .unwrap_or_default()
-                .into_iter()
-                .map(|(key, value)| (key, value.to_string()))
-                .collect(),
-        },
-        campaign: provider::Campaign {
-            name: p
-                .campaign
-                .clone()
-                .unwrap_or_default()
-                .name
-                .unwrap_or_default(),
-            source: p
-                .campaign
-                .clone()
-                .unwrap_or_default()
-                .source
-                .unwrap_or_default(),
-            medium: p
-                .campaign
-                .clone()
-                .unwrap_or_default()
-                .medium
-                .unwrap_or_default(),
-            term: p
-                .campaign
-                .clone()
-                .unwrap_or_default()
-                .term
-                .unwrap_or_default(),
-            content: p
-                .campaign
-                .clone()
-                .unwrap_or_default()
-                .content
-                .unwrap_or_default(),
-            creative_format: p
-                .campaign
-                .clone()
-                .unwrap_or_default()
-                .creative_format
-                .unwrap_or_default(),
-            marketing_tactic: p
-                .campaign
-                .clone()
-                .unwrap_or_default()
-                .marketing_tactic
-                .unwrap_or_default(),
-        },
-        client: provider::Client {
-            ip: anonymize_ip(&p.client.clone().unwrap_or_default().ip.unwrap_or_default()),
-            locale: p
-                .client
-                .clone()
-                .unwrap_or_default()
-                .locale
-                .unwrap_or_default(),
-            timezone: p
-                .client
-                .clone()
-                .unwrap_or_default()
-                .timezone
-                .unwrap_or_default(),
-            user_agent: p
-                .client
-                .clone()
-                .unwrap_or_default()
-                .user_agent
-                .unwrap_or_default(),
-            user_agent_architecture: p
-                .client
-                .clone()
-                .unwrap_or_default()
-                .user_agent_architecture
-                .unwrap_or_default(),
-            user_agent_bitness: p
-                .client
-                .clone()
-                .unwrap_or_default()
-                .user_agent_bitness
-                .unwrap_or_default(),
-            user_agent_full_version_list: p
-                .client
-                .clone()
-                .unwrap_or_default()
-                .user_agent_full_version_list
-                .unwrap_or_default(),
-            user_agent_mobile: p
-                .client
-                .clone()
-                .unwrap_or_default()
-                .user_agent_mobile
-                .unwrap_or_default(),
-            user_agent_model: p
-                .client
-                .clone()
-                .unwrap_or_default()
-                .user_agent_model
-                .unwrap_or_default(),
-            os_name: p
-                .client
-                .clone()
-                .unwrap_or_default()
-                .os_name
-                .unwrap_or_default(),
-            os_version: p
-                .client
-                .clone()
-                .unwrap_or_default()
-                .os_version
-                .unwrap_or_default(),
-            screen_width: p
-                .client
-                .clone()
-                .unwrap_or_default()
-                .screen_width
-                .unwrap_or_default(),
-            screen_height: p
-                .client
-                .clone()
-                .unwrap_or_default()
-                .screen_height
-                .unwrap_or_default(),
-            screen_density: p
-                .client
-                .clone()
-                .unwrap_or_default()
-                .screen_density
-                .unwrap_or_default(),
-            continent: String::new(),
-            country_code: String::new(),
-            country_name: String::new(),
-            region: String::new(),
-            city: String::new(),
-        },
-        session: provider::Session {
-            session_id: p.session.clone().unwrap_or_default().session_id,
-            previous_session_id: p
-                .session
-                .clone()
-                .unwrap_or_default()
-                .previous_session_id
-                .unwrap_or_default(),
-            session_count: p.session.clone().unwrap_or_default().session_count,
-            session_start: p.session.clone().unwrap_or_default().session_start,
-            first_seen: p.session.clone().unwrap_or_default().first_seen.timestamp(),
-            last_seen: p.session.clone().unwrap_or_default().last_seen.timestamp(),
-        },
+    // Convert the payload to the one which can be passed to the component
+    let payload: provider::Payload = p.clone().into();
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()?;
+
+    let event_str = match payload.event_type {
+        provider::EventType::Page => "page",
+        provider::EventType::Identify => "identify",
+        provider::EventType::Track => "track",
     };
+
+    let forwarded_for = HeaderValue::from_str(&payload.client.ip)?;
+    let user_agent = HeaderValue::from_str(&payload.client.user_agent)?;
 
     for cfg in config.components.data_collection.iter() {
         if !p.is_destination_enabled(&cfg.name) {
@@ -268,142 +59,96 @@ pub async fn send_data_collection(p: Payload) -> anyhow::Result<()> {
         let provider = instance.provider();
         let credentials: Vec<(String, String)> = cfg.credentials.clone().into_iter().collect();
 
-        let request = match p.event_type {
-            Some(EventType::Page) => provider.call_page(&mut store, &payload, &credentials).await,
-            Some(EventType::Track) => {
+        let request = match payload.event_type {
+            provider::EventType::Page => {
+                provider.call_page(&mut store, &payload, &credentials).await
+            }
+            provider::EventType::Track => {
                 provider
                     .call_track(&mut store, &payload, &credentials)
                     .await
             }
-            Some(EventType::Identify) => {
+            provider::EventType::Identify => {
                 provider
                     .call_identify(&mut store, &payload, &credentials)
                     .await
             }
-            _ => Err(anyhow::anyhow!("invalid event type")),
+        };
+        let request = match request {
+            Ok(Ok(request)) => request,
+            Ok(Err(err)) => {
+                error!(target: "data_collection", provider = cfg.name, event = event_str, err = err.to_string(), "failed to handle data collection payload");
+                continue;
+            }
+            Err(err) => {
+                error!(target: "data_collection", provider = cfg.name, event = event_str, err = err.to_string(), "failed to handle data collection payload");
+                continue;
+            }
         };
 
-        let event_str = match payload.event_type {
-            provider::EventType::Page => "page",
-            provider::EventType::Identify => "identify",
-            provider::EventType::Track => "track",
-        };
+        let mut headers = HeaderMap::new();
+        for (key, value) in request.headers.iter() {
+            headers.insert(HeaderName::from_str(key)?, HeaderValue::from_str(value)?);
+        }
+        headers.insert(
+            HeaderName::from_str("x-forwarded-for")?,
+            forwarded_for.clone(),
+        );
+        headers.insert(http::header::USER_AGENT, user_agent.clone());
 
-        match request {
-            Ok(res) => match res {
-                Ok(req) => {
-                    let mut headers = HeaderMap::new();
-                    for (key, value) in req.headers {
-                        headers.insert(HeaderName::from_str(&key)?, HeaderValue::from_str(&value)?);
+        let client = client.clone();
+
+        // spawn a separated async thread
+        tokio::spawn(async move {
+            let method_str = match request.method {
+                provider::HttpMethod::Get => "GET",
+                provider::HttpMethod::Put => "PUT",
+                provider::HttpMethod::Post => "POST",
+                provider::HttpMethod::Delete => "DELETE",
+            };
+            info!(target: "data_collection", step = "request", provider = cfg.name, event = event_str, method = method_str, url = request.url, body = request.body);
+
+            let res = match request.method {
+                provider::HttpMethod::Get => client.get(request.url).headers(headers).send().await,
+                provider::HttpMethod::Put => {
+                    client
+                        .put(request.url)
+                        .headers(headers)
+                        .body(request.body)
+                        .send()
+                        .await
+                }
+                provider::HttpMethod::Post => {
+                    client
+                        .post(request.url)
+                        .headers(headers)
+                        .body(request.body)
+                        .send()
+                        .await
+                }
+                provider::HttpMethod::Delete => {
+                    client.delete(request.url).headers(headers).send().await
+                }
+            };
+
+            match res {
+                Ok(res) => {
+                    if res.status().is_success() {
+                        let status_str = format!("{:?}", res.status());
+                        let body_res_str = res.text().await.unwrap_or_default();
+                        info!(target: "data_collection", step = "response", provider = cfg.name, event = event_str, method = method_str, status = status_str, body = body_res_str);
+                    } else {
+                        let status_str = format!("{:?}", res.status());
+                        let body_res_str = res.text().await.unwrap_or_default();
+                        error!(target: "data_collection", step = "response", provider = cfg.name, event = event_str, method = method_str, status = status_str, body = body_res_str);
                     }
-                    headers.insert(
-                        HeaderName::from_str("x-forwarded-for")?,
-                        HeaderValue::from_str(
-                            p.client
-                                .clone()
-                                .unwrap_or_default()
-                                .ip
-                                .unwrap_or_default()
-                                .as_str(),
-                        )?,
-                    );
-                    headers.insert(
-                        HeaderName::from_str("user-agent")?,
-                        HeaderValue::from_str(
-                            p.client
-                                .clone()
-                                .unwrap_or_default()
-                                .user_agent
-                                .unwrap_or_default()
-                                .as_str(),
-                        )?,
-                    );
-
-                    let client = reqwest::Client::builder()
-                        .timeout(Duration::from_secs(5))
-                        .build()?;
-
-                    // spawn a separated async thread
-                    tokio::spawn(async move {
-                        let method_str = match req.method {
-                            provider::HttpMethod::Get => "GET",
-                            provider::HttpMethod::Put => "PUT",
-                            provider::HttpMethod::Post => "POST",
-                            provider::HttpMethod::Delete => "DELETE",
-                        };
-                        info!(target: "data_collection", step = "request", provider = cfg.name, event = event_str, method = method_str, url = req.url, body = req.body);
-                        let res = match req.method {
-                            provider::HttpMethod::Get => {
-                                client.get(req.url).headers(headers).send().await
-                            }
-                            provider::HttpMethod::Put => {
-                                client
-                                    .put(req.url)
-                                    .headers(headers)
-                                    .body(req.body)
-                                    .send()
-                                    .await
-                            }
-                            provider::HttpMethod::Post => {
-                                client
-                                    .post(req.url)
-                                    .headers(headers)
-                                    .body(req.body)
-                                    .send()
-                                    .await
-                            }
-                            provider::HttpMethod::Delete => {
-                                client.delete(req.url).headers(headers).send().await
-                            }
-                        };
-
-                        match res {
-                            Ok(res) => {
-                                if res.status().is_success() {
-                                    let status_str = format!("{:?}", res.status());
-                                    let body_res_str = res.text().await.unwrap_or_default();
-                                    info!(target: "data_collection", step = "response", provider = cfg.name, event = event_str, method = method_str, status = status_str, body = body_res_str);
-                                } else {
-                                    let status_str = format!("{:?}", res.status());
-                                    let body_res_str = res.text().await.unwrap_or_default();
-                                    error!(target: "data_collection", step = "response", provider = cfg.name, event = event_str, method = method_str, status = status_str, body = body_res_str);
-                                }
-                            }
-                            Err(err) => {
-                                error!(target: "data_collection", step = "response", provider = cfg.name, event = event_str, method = method_str, err = err.to_string());
-                            }
-                        }
-                    });
                 }
                 Err(err) => {
-                    error!(target: "data_collection", provider = cfg.name, event = event_str, err = err.to_string(), "failed to handle data collection payload");
+                    error!(target: "data_collection", step = "response", provider = cfg.name, event = event_str, method = method_str, err = err.to_string());
                 }
-            },
-            Err(err) => {
-                error!(target: "data_collection", provider = cfg.name, event = event_str, err = err.to_string(), "failed to call data collection wasm component");
             }
-        }
+        });
     }
 
     Ok(())
-}
-
-fn anonymize_ip(ip: &String) -> String {
-    let mut ip = ip.parse::<IpAddr>().unwrap();
-    const KEEP_IPV4_BYTES: usize = 3;
-    const KEEP_IPV6_BYTES: usize = 6;
-
-    ip = match ip {
-        IpAddr::V4(ip) => {
-            let mut o = ip.octets();
-            o[KEEP_IPV4_BYTES..].copy_from_slice(&[0; 4 - KEEP_IPV4_BYTES]);
-            IpAddr::V4(o.into())
-        }
-        IpAddr::V6(ip) => {
-            let mut o = ip.octets();
-            o[KEEP_IPV6_BYTES..].copy_from_slice(&[0; 16 - KEEP_IPV6_BYTES]);
-            IpAddr::V6(o.into())
-        }
-    };
-    ip.to_string()
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

- Enable the `async` toggle in wasmtime component codegen for getting full async API
- Call data collection in a separate tokio task as to not blocking request handling
- Pre-instantiate data collection components at startup (make startup of `edgee` taking a bit longer as compromise)
- Cleanup components code
	- Move payload processing into a dedicated module and make use of Rust `From` trait
	- Move code out of `loop {}` to only compute once some values
	- Remove some `.unwrap()` by re-using already computed values

### Related Issues

- #92 