### PR TITLE
fix: do not override backend set-cookie when setting edgee cookie

### DIFF
--- a/src/proxy/controller.rs
+++ b/src/proxy/controller.rs
@@ -202,10 +202,9 @@ pub fn build_response(mut parts: http::response::Parts, body: Bytes) -> Response
     parts.headers.insert("content-length", body.len().into());
 
     let mut builder = http::Response::builder();
-    for (name, value) in parts.headers {
-        if name.is_some() {
-            builder = builder.header(name.unwrap(), value);
-        }
+
+    for (name, value) in parts.headers.iter() {
+        builder = builder.header(name, value);
     }
     builder
         .status(parts.status)

--- a/src/tools/edgee_cookie.rs
+++ b/src/tools/edgee_cookie.rs
@@ -330,7 +330,7 @@ fn set_cookie(value: &str, response: &mut Parts, host: &str) {
         .same_site(SameSite::Lax)
         .expires(OffsetDateTime::now_utc() + StdDuration::from_secs(365 * 24 * 60 * 60));
 
-    response.headers.insert(
+    response.headers.append(
         SET_COOKIE,
         HeaderValue::from_str(cookie.to_string().as_str()).unwrap(),
     );


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Backend Set-Cookie were overriden when setting the edgee cookie, this fix append a new Set-Cookie header for the edgee cookie.

Tested against a Flask backend which sets a cookie on each request:

```
response.headers before: "set-cookie": "my_cookie=cookie_value; HttpOnly; Path=/"
response.headers after: "set-cookie": "my_cookie=cookie_value; HttpOnly; Path=/", "set-cookie": "edgee=f549f7f14c02725c9d7f6f0d520ae6dc79bed4beeedcde01b77ea43a5573788e97cd64ff976d930227469b7bf3f45afa9d7cfd1d1a4eafae08b92152c3d0dd16333779d8186d1a94e68fe9e1b34d34ce27a3c1f810e7eb404339a1d37996be483cb730b5f037cba1fdd5aec759a7416ed89bc5fba4232efcde7416f6b21d6c86bcc46a0eafb864ac900806c2ec6a29a23a5284c129d50c6de0235ef36768c4e0d9b8d2f17c67efbc066979b43c9eac9ad0c999fc83d9841af3c3cd9c374b434bba64a8468d1c99d5abdef093ddef2e13; SameSite=Lax; Path=/; Domain=edgee.dev; Expires=Wed, 19 Nov 2025 07:22:54 GMT"
```

### Related Issues

Fixes https://github.com/edgee-cloud/edgee/issues/126
