### PR TITLE
fix: add cookie_domain option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,7 @@ pub struct StaticConfiguration {
 fn default_compute_config() -> ComputeConfiguration {
     ComputeConfiguration {
         cookie_name: default_cookie_name(),
+        cookie_domain: None,
         aes_key: default_aes_key(),
         aes_iv: default_aes_iv(),
         behind_proxy_cache: false,
@@ -182,6 +183,7 @@ pub struct DataCollectionConfiguration {
 pub struct ComputeConfiguration {
     #[serde(default = "default_cookie_name")]
     pub cookie_name: String,
+    pub cookie_domain: Option<String>,
     #[serde(default = "default_aes_key")]
     pub aes_key: String,
     #[serde(default = "default_aes_iv")]

--- a/src/tools/edgee_cookie.rs
+++ b/src/tools/edgee_cookie.rs
@@ -321,9 +321,13 @@ fn init_and_set_cookie(
 /// This function will panic if the `HeaderValue::from_str` function fails to convert the cookie string to a `HeaderValue`.
 fn set_cookie(value: &str, response: &mut Parts, host: &str) {
     let secure = config::get().http.is_some() && config::get().http.as_ref().unwrap().force_https;
-    let root_domain = get_root_domain(host);
+    let cookie_domain = config::get()
+        .compute
+        .cookie_domain
+        .clone()
+        .unwrap_or_else(|| get_root_domain(host));
     let cookie = Cookie::build((&config::get().compute.cookie_name, value))
-        .domain(root_domain)
+        .domain(cookie_domain)
         .path("/")
         .http_only(false)
         .secure(secure)


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

When Edgee is installed in a complex network routing, it could listen to a specific host which is not the same than the one used by the client. 
In that case, edgee user must be able to specify a cookie_domain.

### Related Issues

No related issue
