### PR TITLE
feat: warm-up cookie

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,7 +911,7 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "edgee"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "addr",
  "aes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "edgee"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Edgee <opensource@edgee.cloud>"]
 description = "The full-stack edge platform for your edge oriented applications"
 keywords = ["Edgee"]

--- a/src/proxy/compute/mod.rs
+++ b/src/proxy/compute/mod.rs
@@ -55,7 +55,7 @@ pub async fn html_handler(
 
     match do_process_payload(request, response) {
         Ok(_) => {
-            if !edgee_cookie::has_cookie(request) {
+            if !edgee_cookie::has_cookie(request, response) {
                 set_edgee_header(response, "compute-aborted(no-cookie)");
             } else {
                 let events = data_collection::process_from_html(&document, request, response).await;

--- a/src/tools/edgee_cookie.rs
+++ b/src/tools/edgee_cookie.rs
@@ -138,8 +138,14 @@ pub fn get_or_set(request: &RequestHandle, response: &mut Parts, payload: &Paylo
     edgee_cookie.unwrap()
 }
 
-pub fn has_cookie(request: &RequestHandle) -> bool {
-    get_cookie(request).is_some()
+pub fn has_cookie(request: &RequestHandle, response: &mut Parts) -> bool {
+    let cookie = get_cookie(request).is_some();
+    if cookie {
+        true
+    } else {
+        set_cookie("1", response, request.get_host().as_str());
+        false
+    }
 }
 
 pub fn get_cookie(request: &RequestHandle) -> Option<String> {
@@ -247,6 +253,10 @@ fn decrypt_and_update(
     encrypted_edgee_cookie: &str,
     payload: &Payload,
 ) -> Result<EdgeeCookie, &'static str> {
+    if encrypted_edgee_cookie == "1" {
+        return Err("No cookie found");
+    }
+
     let edgee_cookie_decrypted = decrypt(encrypted_edgee_cookie);
     if edgee_cookie_decrypted.is_err() {
         return Err("Failed to decrypt edgee_cookie");


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

## Cookie Initialization Enhancement

Added fallback cookie initialization for browsers where client-side SDK might fail. Previously, tracking relied entirely on successful client-side data collection to set the initial cookie. Now:

- If no cookie exists, we set a temporary cookie with value "1"
- This ensures the next request triggers edge-side data collection
- Improves tracking reliability for browsers with limited SDK compatibility

### Technical Details
Modified `has_cookie()` to proactively set a temporary cookie when no cookie is found, rather than just returning the check result. This temporary cookie serves as a marker for subsequent requests to initiate proper edge-side data collection.

### Related Issues

No issue
