### PR TITLE
feat: Prevent search engine indexing of data collection endpoints

### DIFF
--- a/src/proxy/controller.rs
+++ b/src/proxy/controller.rs
@@ -20,6 +20,7 @@ pub async fn edgee_client_event(ctx: IncomingContext) -> anyhow::Result<Response
         .status(StatusCode::NO_CONTENT)
         .header(header::CONTENT_TYPE, "application/json")
         .header(header::CACHE_CONTROL, "private, no-store")
+        .header("X-Robots-Tag", "noindex, nofollow")
         .body(empty())?;
 
     let (mut response, _incoming) = res.into_parts();
@@ -53,6 +54,7 @@ pub async fn edgee_client_event_from_third_party_sdk(
         .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
         .header(header::CONTENT_TYPE, "application/json")
         .header(header::CACHE_CONTROL, "private, no-store")
+        .header("X-Robots-Tag", "noindex, nofollow")
         .body(empty())?;
     let (mut response, _incoming) = res.into_parts();
 
@@ -117,6 +119,15 @@ pub async fn edgee_client_event_from_third_party_sdk(
     }
 
     Ok(build_response(response, Bytes::new()))
+}
+
+pub fn empty_json_response() -> anyhow::Result<Response> {
+    Ok(http::Response::builder()
+        .status(StatusCode::GONE)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::CACHE_CONTROL, "private, no-store")
+        .header("X-Robots-Tag", "noindex, nofollow")
+        .body(empty())?)
 }
 
 pub fn options(allow_methods: &str) -> anyhow::Result<Response> {

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -73,19 +73,21 @@ pub async fn handle_request(
     }
 
     // event path, method POST and content-type application/json
-    if request.get_method() == Method::POST
-        && request.get_content_type() == "application/json"
-        && (request.get_path() == DATA_COLLECTION_ENDPOINT
-            || edgee_path::validate(request.get_host().as_str(), request.get_path()))
+    if request.get_path() == DATA_COLLECTION_ENDPOINT
+        || edgee_path::validate(request.get_host().as_str(), request.get_path())
     {
-        info!(
-            "204 - {} {}{} - {}ms",
-            request.get_method(),
-            request.get_host(),
-            request.get_path(),
-            timer_start.elapsed().as_millis()
-        );
-        return controller::edgee_client_event(ctx).await;
+        if request.get_method() == Method::POST && request.get_content_type() == "application/json"
+        {
+            info!(
+                "204 - {} {}{} - {}ms",
+                request.get_method(),
+                request.get_host(),
+                request.get_path(),
+                timer_start.elapsed().as_millis()
+            );
+            return controller::edgee_client_event(ctx).await;
+        }
+        return controller::empty_json_response();
     }
 
     // event path for third party integration (Edgee installed like a third party, and use localstorage)
@@ -111,6 +113,7 @@ pub async fn handle_request(
             );
             return controller::edgee_client_event_from_third_party_sdk(ctx).await;
         }
+        return controller::empty_json_response();
     }
 
     // define the backend


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

#### Prevent search engine indexing of data collection endpoints

Returns 410 Gone for GET requests to data collection endpoints (`/_edgee/event`, `/_edgee/csevent`, and generated data collection paths) to prevent search engine indexing. Only POST requests with `application/json` content-type are valid for these endpoints.

##### Changes
- Updated condition checks in `handle_request` to return `empty_json_response` (410 Gone) for non-POST requests
- Maintains existing behavior for POST/OPTIONS requests
- Add "X-Robots-Tag: noindex, nofollow" header

##### Testing
- [x] GET requests return 410 Gone
- [x] POST requests work as expected
- [x] OPTIONS requests still work for CORS

### Related Issues

#139 
