### PR TITLE
chore: bump edgee to version v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "edgee"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "edgee-path"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3554c7d421dab323cda42f297fc1591f1d89049f7e67d477f4dc1caf735b5ead"
+checksum = "d27186522959c93bb0679c2cf3b3e982321673761d7947ce891bfab39ca6c0fe"
 dependencies = [
  "rand",
 ]
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "edgee-server"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "addr",
  "aes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Edgee <opensource@edgee.cloud>"]
 license = "Apache-2.0"
 keywords = ["edgee"]
@@ -61,6 +61,6 @@ wasmtime = "27.0.0"
 wasmtime-wasi = "27.0.0"
 
 edgee-sdk = "1.2.0"
-edgee-path = "0.1.0"
+edgee-path = "0.1.1"
 
-edgee-server = { version = "0.5.0", path = "crates/server" }
+edgee-server = { version = "0.6.0", path = "crates/server" }


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Now Edgee is ready to have a real CLI experience, I suggest creating the v0.6.0 to prepare for the next v1.0.0
I take this opportunity to bump the edgee-path version as well.

### Related Issues

No issue
