### PR TITLE
feat: products properties

### DIFF
--- a/crates/server/src/proxy/compute/data_collection/components/convert.rs
+++ b/crates/server/src/proxy/compute/data_collection/components/convert.rs
@@ -20,6 +20,7 @@ impl From<payload::Event> for provider::Event {
             event_type: value.event_type.into(),
             data,
             context: value.context.unwrap_or_default().into(),
+            consent: provider::Consent::Pending,
         }
     }
 }

--- a/crates/server/src/proxy/compute/data_collection/components/convert.rs
+++ b/crates/server/src/proxy/compute/data_collection/components/convert.rs
@@ -46,7 +46,6 @@ impl From<payload::Page> for provider::PageData {
             search: value.search.unwrap_or_default(),
             referrer: value.referrer.unwrap_or_default(),
             properties: convert_properties(value.properties.clone()),
-            products: convert_products(value.properties.clone()),
         }
     }
 }

--- a/crates/server/src/proxy/compute/data_collection/components/convert.rs
+++ b/crates/server/src/proxy/compute/data_collection/components/convert.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use tracing::warn;
 
 use super::exports::provider;
 use crate::proxy::compute::data_collection::payload;
@@ -168,20 +169,24 @@ fn convert_products(
     let Some(dict) = properties else {
         return Vec::new();
     };
-    
 
     // if the key is products, then we need to convert the value to a list of tuples
     if let Some(products) = dict.get("products") {
         // if products is not an array, return an empty vector
         if !products.is_array() {
+            warn!("data.properties.products is not an array, skipping");
             return Vec::new();
         }
 
         let mut results: Vec<Vec<(String, String)>> = Vec::new();
         let items = products.as_array().unwrap();
-        items.iter().for_each(|product| {
+        items.iter().enumerate().for_each(|(index, product)| {
             // if product is not an object, go to the next product
             if !product.is_object() {
+                warn!(
+                    "data.properties.products[{}] is not an object, skipping",
+                    index
+                );
                 return;
             }
 
@@ -198,7 +203,7 @@ fn convert_products(
                     (k, value)
                 })
                 .for_each(|tuple| i.push(tuple));
-            
+
             results.push(i);
         });
         results

--- a/crates/server/wit/protocols.wit
+++ b/crates/server/wit/protocols.wit
@@ -32,7 +32,6 @@ world data-collection {
             search: string,
             referrer: string,
             properties: dict,
-            products: list<dict>,
         }
 
         record user-data {

--- a/crates/server/wit/protocols.wit
+++ b/crates/server/wit/protocols.wit
@@ -1,4 +1,4 @@
-package edgee:protocols@0.2.2;
+package edgee:protocols@0.2.3;
 
 world data-collection {
     export provider: interface {
@@ -32,6 +32,7 @@ world data-collection {
             search: string,
             referrer: string,
             properties: dict,
+            products: list<dict>,
         }
 
         record user-data {
@@ -44,6 +45,7 @@ world data-collection {
         record track-data {
             name: string,
             properties: dict,
+            products: list<dict>,
         }
 
         record context {

--- a/crates/server/wit/protocols.wit
+++ b/crates/server/wit/protocols.wit
@@ -5,6 +5,7 @@ world data-collection {
         type dict = list<tuple<string,string>>;
 
         enum event-type { page, track, user }
+        enum consent { pending, granted, denied }
 
         record event {
             uuid: string,
@@ -14,6 +15,7 @@ world data-collection {
             event-type: event-type,
             data: data,
             context: context,
+            consent: consent,
         }
 
         variant data {


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

For now, Edgee data collection components can only collect standard events (pageviews, identify, simple custom event). To be complete, a user has to be able to send e-commerce data to his analytics providers. 
Following the [GA4 e-commerce spec](https://developers.google.com/analytics/devguides/collection/ga4/ecommerce?hl=en&client_type=gtag) and [Segment doc](https://segment.com/docs/connections/spec/ecommerce/v2/), I added the interpretation of a `products` array in the `data.properties` of a track event. 

### Related Issues

No issue
