### PR TITLE
cli: Add auth command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -254,7 +254,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -270,6 +270,12 @@ dependencies = [
  "syn",
  "which",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -458,7 +464,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -739,6 +745,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,7 +859,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -840,6 +880,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -871,18 +923,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
 name = "edgee"
 version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
+ "edgee-components",
  "edgee-server",
+ "inquire",
  "openssl",
  "serde_yml",
  "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "edgee-components"
+version = "0.6.0"
+dependencies = [
+ "anyhow",
+ "dirs 5.0.1",
+ "reqwest",
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -1185,6 +1256,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,7 +1279,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "debugid",
  "fxhash",
  "serde",
@@ -1646,6 +1726,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "io-extras"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,7 +1876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1794,7 +1891,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -1819,6 +1916,16 @@ name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1888,6 +1995,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
@@ -1912,6 +2031,15 @@ dependencies = [
  "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1973,7 +2101,7 @@ version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2022,10 +2150,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "paste"
@@ -2218,6 +2375,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2367,7 +2533,7 @@ version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "errno",
  "itoa",
  "libc",
@@ -2447,12 +2613,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -2465,7 +2637,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -2615,7 +2787,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
 dependencies = [
- "dirs",
+ "dirs 4.0.0",
 ]
 
 [[package]]
@@ -2623,6 +2795,36 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -2731,7 +2933,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2752,7 +2954,7 @@ version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "cap-fs-ext",
  "cap-std",
  "fd-lock",
@@ -2870,7 +3072,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 1.0.3",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -2976,7 +3178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.6.0",
  "bytes",
  "futures-core",
  "http",
@@ -3092,6 +3294,18 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -3283,7 +3497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c771866898879073c53b565a6c7b49953795159836714ac56a5befb581227c5"
 dependencies = [
  "ahash",
- "bitflags",
+ "bitflags 2.6.0",
  "hashbrown 0.14.5",
  "indexmap 2.7.0",
  "semver",
@@ -3296,7 +3510,7 @@ version = "0.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9845c470a2e10b61dd42c385839cdd6496363ed63b5c9e420b5488b77bd22083"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "indexmap 2.7.0",
  "semver",
 ]
@@ -3321,7 +3535,7 @@ dependencies = [
  "addr2line",
  "anyhow",
  "async-trait",
- "bitflags",
+ "bitflags 2.6.0",
  "bumpalo",
  "cc",
  "cfg-if",
@@ -3534,7 +3748,7 @@ checksum = "ad5cf227161565057fc994edf14180341817372a218f1597db48a43946e5f875"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags",
+ "bitflags 2.6.0",
  "bytes",
  "cap-fs-ext",
  "cap-net-ext",
@@ -3603,7 +3817,7 @@ dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
- "unicode-width",
+ "unicode-width 0.2.0",
  "wasm-encoder 0.221.2",
 ]
 
@@ -3646,7 +3860,7 @@ checksum = "80e0f6ef83a263c0fa11957c363aeaa76dc84832484d0e119f22810d4d0e09a7"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags",
+ "bitflags 2.6.0",
  "thiserror",
  "tracing",
  "wasmtime",
@@ -3734,7 +3948,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3745,7 +3959,7 @@ checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3754,7 +3968,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3764,7 +3978,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3773,7 +3996,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3782,7 +4005,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3791,15 +4029,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3809,9 +4053,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3827,9 +4083,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3839,9 +4107,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3864,7 +4144,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ cbc = "0.1.2"
 chrono = "0.4.38"
 clap = "4.5.21"
 cookie = "0.18.1"
+dirs = "5.0.1"
 futures = "0.3.31"
 hex = "0.4.3"
 html-escape = "0.2.13"
@@ -30,6 +31,7 @@ http-body-util = "0.1"
 hyper = "1.5.1"
 hyper-rustls = "0.27.2"
 hyper-util = "0.1.5"
+inquire = "0.7.5"
 ipnetwork = "0.20.0"
 json_comments = "0.2.2"
 json_pretty = "0.1.2"
@@ -63,5 +65,6 @@ wasmtime-wasi = "27.0.0"
 edgee-sdk = "1.2.0"
 edgee-path = "0.1.1"
 
+edgee-components = { version = "0.6.0", path = "crates/components" }
 edgee-server = { version = "0.6.0", path = "crates/server" }
-edgee-wasmtime = { version = "0.6.0", path = "crates/wasmtime"}
+edgee-wasmtime = { version = "0.6.0", path = "crates/wasmtime" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,6 +12,7 @@ edition.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
+inquire.workspace = true
 openssl.workspace = true
 serde_yml.workspace = true
 tracing.workspace = true
@@ -19,6 +20,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 
+edgee-components.workspace = true
 edgee-server.workspace = true
 
 [features]

--- a/crates/cli/src/commands/auth/login.rs
+++ b/crates/cli/src/commands/auth/login.rs
@@ -15,9 +15,7 @@ pub async fn run(_opts: Options) {
     }
 
     let api_token = Password::new("Enter Edgee API token (press Ctrl+R to toggle input display):")
-        .with_help_message(
-            "You can create one at https://www.edgee.cloud/<username>/settings/tokens",
-        )
+        .with_help_message("You can create one at https://www.edgee.cloud/me/settings/tokens")
         .with_display_mode(PasswordDisplayMode::Masked)
         .with_display_toggle_enabled()
         .without_confirmation()

--- a/crates/cli/src/commands/auth/login.rs
+++ b/crates/cli/src/commands/auth/login.rs
@@ -1,0 +1,30 @@
+setup_command! {}
+
+pub async fn run(_opts: Options) {
+    use inquire::{Confirm, Text};
+
+    use edgee_components::auth::Credentials;
+
+    let mut creds = Credentials::load().unwrap();
+
+    let confirm_overwrite =
+        Confirm::new("An API token is already present, do you want to overwrite it?")
+            .with_default(false);
+    if creds.api_token.is_some() && !confirm_overwrite.prompt().unwrap() {
+        return;
+    }
+
+    let api_token = Text::new("Enter Edgee API token:").prompt().unwrap();
+    creds.api_token.replace(api_token);
+
+    let user = match creds.fetch_user().await {
+        Ok(user) => user,
+        Err(err) => {
+            tracing::error!("{err:?}");
+            return;
+        }
+    };
+    println!("Logged as {} ({})", user.name, user.email);
+
+    creds.save().unwrap();
+}

--- a/crates/cli/src/commands/auth/login.rs
+++ b/crates/cli/src/commands/auth/login.rs
@@ -1,7 +1,7 @@
 setup_command! {}
 
 pub async fn run(_opts: Options) {
-    use inquire::{Confirm, Text};
+    use inquire::{Confirm, Password, PasswordDisplayMode};
 
     use edgee_components::auth::Credentials;
 
@@ -14,7 +14,16 @@ pub async fn run(_opts: Options) {
         return;
     }
 
-    let api_token = Text::new("Enter Edgee API token (you can create one at https://www.edgee.cloud/<username>/settings/tokens):").prompt().unwrap();
+    let api_token = Password::new("Enter Edgee API token (press Ctrl+R to toggle input display):")
+        .with_help_message(
+            "You can create one at https://www.edgee.cloud/<username>/settings/tokens",
+        )
+        .with_display_mode(PasswordDisplayMode::Masked)
+        .with_display_toggle_enabled()
+        .without_confirmation()
+        .with_validator(inquire::required!("API token cannot be empty"))
+        .prompt()
+        .unwrap();
     creds.api_token.replace(api_token);
 
     let user = match creds.fetch_user().await {

--- a/crates/cli/src/commands/auth/login.rs
+++ b/crates/cli/src/commands/auth/login.rs
@@ -14,7 +14,7 @@ pub async fn run(_opts: Options) {
         return;
     }
 
-    let api_token = Text::new("Enter Edgee API token:").prompt().unwrap();
+    let api_token = Text::new("Enter Edgee API token (you can create one at https://www.edgee.cloud/<username>/settings/tokens):").prompt().unwrap();
     creds.api_token.replace(api_token);
 
     let user = match creds.fetch_user().await {

--- a/crates/cli/src/commands/auth/mod.rs
+++ b/crates/cli/src/commands/auth/mod.rs
@@ -3,11 +3,8 @@ setup_commands! {
     Whoami(whoami),
 }
 
-setup_command! {
-    #[command(subcommand)]
-    command: Command,
-}
+pub type Options = Command;
 
-pub async fn run(opts: Options) {
-    opts.command.run().await
+pub async fn run(command: Command) {
+    command.run().await
 }

--- a/crates/cli/src/commands/auth/mod.rs
+++ b/crates/cli/src/commands/auth/mod.rs
@@ -1,5 +1,7 @@
 setup_commands! {
+    /// Log in to the Edgee Console
     Login(login),
+    /// Print currently login informations
     Whoami(whoami),
 }
 

--- a/crates/cli/src/commands/auth/mod.rs
+++ b/crates/cli/src/commands/auth/mod.rs
@@ -1,0 +1,13 @@
+setup_commands! {
+    Login(login),
+    Whoami(whoami),
+}
+
+setup_command! {
+    #[command(subcommand)]
+    command: Command,
+}
+
+pub async fn run(opts: Options) {
+    opts.command.run().await
+}

--- a/crates/cli/src/commands/auth/whoami.rs
+++ b/crates/cli/src/commands/auth/whoami.rs
@@ -4,6 +4,11 @@ pub async fn run(_opts: Options) {
     use edgee_components::auth::Credentials;
 
     let creds = Credentials::load().unwrap();
+    if creds.api_token.is_none() {
+        eprintln!("Not logged in");
+        return;
+    }
+
     let user = creds.fetch_user().await.unwrap();
 
     println!("Logged in as:");

--- a/crates/cli/src/commands/auth/whoami.rs
+++ b/crates/cli/src/commands/auth/whoami.rs
@@ -12,6 +12,7 @@ pub async fn run(_opts: Options) {
     let user = creds.fetch_user().await.unwrap();
 
     println!("Logged in as:");
+    println!("  ID:    {}", user.id);
     println!("  Name:  {}", user.name);
     println!("  Email: {}", user.email);
 }

--- a/crates/cli/src/commands/auth/whoami.rs
+++ b/crates/cli/src/commands/auth/whoami.rs
@@ -1,0 +1,12 @@
+setup_command! {}
+
+pub async fn run(_opts: Options) {
+    use edgee_components::auth::Credentials;
+
+    let creds = Credentials::load().unwrap();
+    let user = creds.fetch_user().await.unwrap();
+
+    println!("Logged in as:");
+    println!("  Name:  {}", user.name);
+    println!("  Email: {}", user.email);
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@
 mod macros;
 
 setup_commands! {
+    Auth(auth),
     #[command(visible_alias = "server")]
     Serve(serve),
 }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2,5 +2,6 @@
 mod macros;
 
 setup_commands! {
+    #[command(visible_alias = "server")]
     Serve(serve),
 }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -4,6 +4,7 @@ mod macros;
 setup_commands! {
     #[command(flatten)]
     Auth(auth),
+    /// Run the Edgee server
     #[command(visible_alias = "server")]
     Serve(serve),
 }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@
 mod macros;
 
 setup_commands! {
+    #[command(flatten)]
     Auth(auth),
     #[command(visible_alias = "server")]
     Serve(serve),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -12,15 +12,11 @@ struct Options {
     #[arg(long, env = "EDGEE_LOG_FORMAT", value_enum, default_value_t)]
     log_format: logger::LogFormat,
 
-    #[arg(short = 'f', long = "config", env = "EDGEE_CONFIG_PATH")]
+    #[arg(short, long = "config", env = "EDGEE_CONFIG_PATH")]
     config_path: Option<PathBuf>,
 
-    #[arg(
-        short = 'c',
-        long = "debug-component",
-        help = "Launch Edgee and log only the specified component requests and responses to debug.",
-        id = "COMPONENT_NAME"
-    )]
+    /// Log only the specified component's requests and responses to debug.
+    #[arg(short, long, id = "COMPONENT_NAME")]
     debug_component: Option<String>,
 
     #[command(subcommand)]

--- a/crates/components/Cargo.toml
+++ b/crates/components/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "edgee-components"
+description = "Edgee crate for authoring, building and publishing components"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+keywords.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+dirs.workspace = true
+reqwest = { workspace = true, features = ["json"] }
+serde = { workspace = true, features = ["derive"] }
+toml.workspace = true

--- a/crates/components/src/auth/mod.rs
+++ b/crates/components/src/auth/mod.rs
@@ -72,9 +72,11 @@ impl Credentials {
             anyhow::bail!("No API token provided");
         };
 
+        let url = format!("{}/v1/users/me", &*crate::API_ENDPOINT_BASE_URL);
+
         let client = Client::new();
         let res = client
-            .get("https://api.edgee.app/v1/users/me")
+            .get(url)
             .bearer_auth(api_token)
             .send()
             .await

--- a/crates/components/src/auth/mod.rs
+++ b/crates/components/src/auth/mod.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use self::models::User;
+
+pub mod models;
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct Credentials {
+    pub api_token: Option<String>,
+}
+
+impl Credentials {
+    pub fn path() -> Result<PathBuf> {
+        let config_dir = dirs::config_dir()
+            .ok_or_else(|| anyhow::anyhow!("Could not get user config directory"))?
+            .join("edgee");
+        if !config_dir.exists() {
+            std::fs::create_dir_all(&config_dir).context("Could not create Edgee config dir")?;
+        }
+
+        Ok(config_dir.join("credentials.toml"))
+    }
+
+    pub fn load() -> Result<Self> {
+        let creds_path = Self::path()?;
+        if !creds_path.exists() {
+            return Ok(Self::default());
+        }
+
+        let content =
+            std::fs::read_to_string(creds_path).context("Could not read credentials file")?;
+        toml::from_str(&content).context("Could not load credentials file")
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let content =
+            toml::to_string_pretty(self).context("Could not serialize credentials data")?;
+
+        let creds_path = Self::path()?;
+        std::fs::write(creds_path, content).context("Could not write credentials data")
+    }
+
+    pub async fn fetch_user(&self) -> Result<User> {
+        use reqwest::Client;
+
+        let Some(ref api_token) = self.api_token else {
+            anyhow::bail!("No API token provided");
+        };
+
+        let client = Client::new();
+        let res = client
+            .get("https://api.edgee.app/v1/users/me")
+            .bearer_auth(api_token)
+            .send()
+            .await
+            .context("Could not send API request")?
+            .error_for_status()?;
+
+        res.json().await.context("Could not decode API response")
+    }
+}

--- a/crates/components/src/auth/models.rs
+++ b/crates/components/src/auth/models.rs
@@ -1,0 +1,9 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct User {
+    pub id: String,
+    pub email: String,
+    pub name: String,
+    pub role: String,
+}

--- a/crates/components/src/lib.rs
+++ b/crates/components/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod auth;

--- a/crates/components/src/lib.rs
+++ b/crates/components/src/lib.rs
@@ -1,1 +1,11 @@
+use std::sync::LazyLock;
+
 pub mod auth;
+
+const DEFAULT_API_ENDPOINT_BASE_URL: &str = "https://api.edgee.cloud";
+pub static API_ENDPOINT_BASE_URL: LazyLock<String> = LazyLock::new(|| {
+    use std::env;
+
+    env::var("EDGEE_API_ENDPOINT_BASE_URL")
+        .unwrap_or_else(|_| DEFAULT_API_ENDPOINT_BASE_URL.to_owned())
+});


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

- Add a new crate `edgee-components` to house the code related to components authoring, building and publishing (and associated utilities)
- Add the new CLI command `auth` with two subcommands:
  * `login`: Ask for an API token which can be created on the console and save it into a credentials file after validation
  * `whoami`: Ask the API for who is the currently logged user, if any

### Usage example

```shell
$ edgee auth login
> Enter Edgee API token (you can create one at https://www.edgee.cloud/<username>/settings/tokens): ******
Logged as Julianne Hervier (julianne@edgee.cloud)
```

### Related Issues

- EDGEE-230