### PR TITLE
fix: cookie parsing is altered when a cookie contains an equal char

### DIFF
--- a/crates/server/src/proxy/context/proxy.rs
+++ b/crates/server/src/proxy/context/proxy.rs
@@ -64,16 +64,13 @@ impl<'a> ProxyContext<'a> {
             let cookie_str = cookie.to_str().unwrap();
             let cookie_parts: Vec<&str> = cookie_str.split(";").map(|c| c.trim()).collect();
             for cookie_part in cookie_parts {
-                let parts: Vec<&str> = cookie_part.split('=').collect();
-                if parts.len() != 2 {
-                    continue;
-                }
-                // Include all cookies except edgee and edgee_u
-                let name = parts[0].trim();
-                if name != config::get().compute.cookie_name
-                    && name != format!("{}_u", config::get().compute.cookie_name)
-                {
-                    filtered_cookies.push(cookie_part.to_string());
+                if let Some((key, _value)) = cookie_part.split_once('=') {
+                    let name = key.trim();
+                    if name != config::get().compute.cookie_name
+                        && name != format!("{}_u", config::get().compute.cookie_name)
+                    {
+                        filtered_cookies.push(cookie_part.to_string());
+                    }
                 }
             }
         }

--- a/crates/server/src/tools/edgee_cookie.rs
+++ b/crates/server/src/tools/edgee_cookie.rs
@@ -181,11 +181,9 @@ pub fn get_cookie(name: &str, request: &RequestHandle) -> Option<String> {
     for cookie in all_cookies {
         let mut map = HashMap::new();
         for item in cookie.to_str().unwrap().split("; ") {
-            let parts: Vec<&str> = item.split('=').collect();
-            if parts.len() != 2 {
-                continue;
+            if let Some((key, value)) = item.split_once('=') {
+                map.insert(key.trim().to_string(), value.trim().to_string());
             }
-            map.insert(parts[0].trim().to_string(), parts[1].trim().to_string());
         }
 
         if map.contains_key(name) {


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

When Edgee parses all the cookies, a cookie that contains an equal sign disappears from the cookies list

### Related Issues

No related issue
