### PR TITLE
fix: event path 410 response becomes 204

### DIFF
--- a/crates/server/src/proxy/controller.rs
+++ b/crates/server/src/proxy/controller.rs
@@ -148,7 +148,7 @@ pub async fn edgee_client_event_from_third_party_sdk(
 
 pub fn empty_json_response() -> anyhow::Result<Response> {
     Ok(http::Response::builder()
-        .status(StatusCode::GONE)
+        .status(StatusCode::NO_CONTENT)
         .header(header::CONTENT_TYPE, "application/json")
         .header(header::CACHE_CONTROL, "private, no-store")
         .header("X-Robots-Tag", "noindex, nofollow")


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The client-side events are collected on a dynamic URL, its path changing with each page change. 
We can see that these URLs show up in Google's search console. Even if they are not indexed, it would be better that bots ignore them. 
When a bot calls these URLs, we serve a 410 with a header `x-robots-tag: noindex, nofollow`. This doesn't seem to be enough, because it seems that the bot doesn't interpret the `x-robots-tag` header on a 410 error.
We now serve a 204

### Related Issues

No issue
