### PR TITLE
feat: use env var to test api locally

### DIFF
--- a/crates/api-client/src/lib.rs
+++ b/crates/api-client/src/lib.rs
@@ -22,6 +22,12 @@ pub fn connect(#[builder(default = PROD_BASEURL)] baseurl: &str, api_token: Stri
 
     let mut default_headers = HeaderMap::new();
 
+    // if API_URL env var is set, redefine baseurl
+    let baseurl = std::env::var("API_URL").unwrap_or(baseurl.to_string());
+
+    // if API_TOKEN env var is set, redefine api_token
+    let api_token = std::env::var("API_TOKEN").unwrap_or(api_token.to_string());
+
     let auth_value = format!("Bearer {api_token}");
     default_headers.insert(header::AUTHORIZATION, auth_value.try_into().unwrap());
 
@@ -30,5 +36,5 @@ pub fn connect(#[builder(default = PROD_BASEURL)] baseurl: &str, api_token: Stri
         .build()
         .unwrap();
 
-    Client::new_with_client(baseurl, client)
+    Client::new_with_client(&baseurl, client)
 }

--- a/crates/api-client/src/lib.rs
+++ b/crates/api-client/src/lib.rs
@@ -22,11 +22,11 @@ pub fn connect(#[builder(default = PROD_BASEURL)] baseurl: &str, api_token: Stri
 
     let mut default_headers = HeaderMap::new();
 
-    // if API_URL env var is set, redefine baseurl
-    let baseurl = std::env::var("API_URL").unwrap_or(baseurl.to_string());
+    // if EDGEE_API_URL env var is set, redefine baseurl
+    let baseurl = std::env::var("EDGEE_API_URL").unwrap_or(baseurl.to_string());
 
-    // if API_TOKEN env var is set, redefine api_token
-    let api_token = std::env::var("API_TOKEN").unwrap_or(api_token.to_string());
+    // if EDGEE_API_TOKEN env var is set, redefine api_token
+    let api_token = std::env::var("EDGEE_API_TOKEN").unwrap_or(api_token.to_string());
 
     let auth_value = format!("Bearer {api_token}");
     default_headers.insert(header::AUTHORIZATION, auth_value.try_into().unwrap());


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

To test edgee with a local version of the api, two env vars can be used to change the API base url and the API token

### Related Issues

No issue
