### PR TITLE
feat: data collection debug endpoints change

### DIFF
--- a/crates/api-client/openapi.json
+++ b/crates/api-client/openapi.json
@@ -2111,7 +2111,7 @@
         }
       }
     },
-    "/v1/projects/{id}/debug/incoming_data_collection_events": {
+    "/v1/projects/{id}/debug/data-collection/incoming": {
       "get": {
         "operationId": "getIncomingDataCollectionEvents",
         "summary": "List all Incoming Data Collection Events",
@@ -2176,7 +2176,7 @@
         }
       }
     },
-    "/v1/projects/{id}/debug/outgoing_data_collection_events/{event_id}": {
+    "/v1/projects/{id}/debug/data-collection/outgoing/{event_id}": {
       "get": {
         "operationId": "getOutgoingDataCollectionEvents",
         "summary": "List all Outgoing Data Collection Events",

--- a/crates/api-client/openapi.json
+++ b/crates/api-client/openapi.json
@@ -2111,7 +2111,7 @@
         }
       }
     },
-    "/v1/projects/{id}/incoming_data_collection_events": {
+    "/v1/projects/{id}/debug/incoming_data_collection_events": {
       "get": {
         "operationId": "getIncomingDataCollectionEvents",
         "summary": "List all Incoming Data Collection Events",
@@ -2176,7 +2176,7 @@
         }
       }
     },
-    "/v1/projects/{id}/outgoing_data_collection_events/{event_id}": {
+    "/v1/projects/{id}/debug/outgoing_data_collection_events/{event_id}": {
       "get": {
         "operationId": "getOutgoingDataCollectionEvents",
         "summary": "List all Outgoing Data Collection Events",

--- a/crates/components-runtime/src/data_collection/debug.rs
+++ b/crates/components-runtime/src/data_collection/debug.rs
@@ -307,7 +307,7 @@ pub async fn debug_and_trace_response(
         let api_url = std::env::var("EDGEE_API_URL").unwrap_or_default();
 
         if !api_super_token.is_empty() && !api_url.is_empty() && !params.project_id.is_empty() {
-            let api_endpoint = format!("{}/v1/debug/data_collection_events", api_url);
+            let api_endpoint = format!("{}/v1/debug/data-collection", api_url);
             let debug_entry = DebugPayload::new(params, &error);
             let client = reqwest::Client::builder()
                 .timeout(Duration::from_secs(5))

--- a/crates/components-runtime/src/data_collection/logger.rs
+++ b/crates/components-runtime/src/data_collection/logger.rs
@@ -7,7 +7,7 @@ use super::debug::DebugParams;
 pub struct Logger {}
 
 impl Logger {
-    pub fn log_outgoing_event(params: &DebugParams, duration: u128) {
+    pub fn log_outgoing_event(params: &DebugParams, duration: u128, error: &str) {
         let path = params.event.context.page.path.clone();
         let event_type = match params.event.event_type {
             EventType::Page => "page",
@@ -37,6 +37,7 @@ impl Logger {
             component = params.component_slug,
             status = params.response_status,
             duration = duration,
+            message = error
         );
     }
 }


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

To reflect API changes: 
- data collection events endpoints now have a `/debug` prefix
- we now use an `Authorization` header instead of `x-api-secret` when debug info is sent to the API from data collection components

### Related Issues

List related issues here
