### PR TITLE
feat: new component configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,9 @@ You simply need to add a new session to your configuration pointing to the WebAs
 ```toml
 # edgee.toml
 [[components.data_collection]]
-name = "amplitude"
-component = "/var/edgee/wasm/amplitude.wasm"
-credentials.amplitude_api_key = "YOUR-API-KEY"
+id = "amplitude"
+file = "/var/edgee/wasm/amplitude.wasm"
+settings.amplitude_api_key = "YOUR-API-KEY"
 ```
 
 ### Debugging a component

--- a/crates/api-client/openapi.json
+++ b/crates/api-client/openapi.json
@@ -2887,6 +2887,11 @@
             "description": "Unique identifier for the component",
             "example": "d290f1ee-6c54-4b01-90e6-d701748f0851"
           },
+          "component_slug": {
+            "type": "string",
+            "description": "Slug of the component",
+            "example": "edgee/google_analytics"
+          },
           "component_version": {
             "type": "string",
             "description": "Version of the component",
@@ -2895,6 +2900,12 @@
           "category": {
             "type": "string",
             "description": "Category of the component",
+            "readOnly": true,
+            "example": "data_collection"
+          },
+          "subcategory": {
+            "type": "string",
+            "description": "Subcategory of the component",
             "readOnly": true,
             "example": "analytics"
           },
@@ -2905,7 +2916,8 @@
           },
           "settings": {
             "type": "object",
-            "description": "Settings of the component"
+            "description": "Settings of the component",
+            "nullable": true
           }
         }
       },
@@ -2944,7 +2956,7 @@
             "description": "Category of the component",
             "readOnly": true
           },
-          "sub_category": {
+          "subcategory": {
             "type": "string",
             "description": "Subcategory of the component",
             "readOnly": true
@@ -3080,7 +3092,7 @@
               "data_collection"
             ]
           },
-          "sub_category": {
+          "subcategory": {
             "type": "string",
             "description": "Subcategory of the component.",
             "enum": [
@@ -3108,7 +3120,7 @@
           "organization_id",
           "name",
           "category",
-          "sub_category"
+          "subcategory"
         ]
       },
       "ComponentUpdateParams" : {
@@ -3192,7 +3204,7 @@
               "data_collection"
             ]
           },
-          "sub_category": {
+          "subcategory": {
             "type": "string",
             "description": "Filter components by sub category.",
             "enum": [

--- a/crates/components-runtime/src/config.rs
+++ b/crates/components-runtime/src/config.rs
@@ -13,34 +13,40 @@ pub struct ComponentsConfiguration {
 
 #[derive(Deserialize, Debug, Default, Clone)]
 pub struct DataCollectionComponents {
+    #[serde(skip_deserializing)]
+    pub project_component_id: String,
+    #[serde(skip_deserializing)]
+    pub slug: String,
+    #[serde(skip_deserializing)]
+    pub subcategory: String,
+    pub id: String, // could be a slug (edgee/amplitude) or an alias (amplitude)
+    pub file: String,
     #[serde(default)]
-    pub id: String,
-    pub name: String,
-    pub component: String,
-    pub credentials: HashMap<String, String>,
-    #[serde(default)]
-    pub config: DataCollectionComponentConfig,
+    pub settings: DataCollectionComponentSettings,
     pub forward_client_headers: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(default)]
-pub struct DataCollectionComponentConfig {
-    pub anonymization: bool,
-    pub default_consent: String,
-    pub track_event_enabled: bool,
-    pub user_event_enabled: bool,
-    pub page_event_enabled: bool,
+pub struct DataCollectionComponentSettings {
+    pub edgee_anonymization: bool,
+    pub edgee_default_consent: String,
+    pub edgee_track_event_enabled: bool,
+    pub edgee_user_event_enabled: bool,
+    pub edgee_page_event_enabled: bool,
+    #[serde(flatten)]
+    pub additional_settings: HashMap<String, String>,
 }
 
-impl Default for DataCollectionComponentConfig {
+impl Default for DataCollectionComponentSettings {
     fn default() -> Self {
-        DataCollectionComponentConfig {
-            anonymization: true,
-            default_consent: "pending".to_string(),
-            track_event_enabled: true,
-            user_event_enabled: true,
-            page_event_enabled: true,
+        DataCollectionComponentSettings {
+            edgee_anonymization: true,
+            edgee_default_consent: "pending".to_string(),
+            edgee_track_event_enabled: true,
+            edgee_user_event_enabled: true,
+            edgee_page_event_enabled: true,
+            additional_settings: HashMap::new(),
         }
     }
 }

--- a/crates/components-runtime/src/config.rs
+++ b/crates/components-runtime/src/config.rs
@@ -17,13 +17,10 @@ pub struct DataCollectionComponents {
     pub project_component_id: String,
     #[serde(skip_deserializing)]
     pub slug: String,
-    #[serde(skip_deserializing)]
-    pub subcategory: String,
     pub id: String, // could be a slug (edgee/amplitude) or an alias (amplitude)
     pub file: String,
     #[serde(default)]
     pub settings: DataCollectionComponentSettings,
-    pub forward_client_headers: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/crates/components-runtime/src/context.rs
+++ b/crates/components-runtime/src/context.rs
@@ -93,10 +93,7 @@ impl ComponentsContext {
         id: &str,
         store: &mut Store<HostState>,
     ) -> anyhow::Result<DataCollection> {
-        let instance_pre = self
-            .components
-            .data_collection
-            .get(id);
+        let instance_pre = self.components.data_collection.get(id);
 
         if instance_pre.is_none() {
             return Err(anyhow::anyhow!("component not found: {}", id));
@@ -114,10 +111,7 @@ impl ComponentsContext {
         id: &str,
         store: &mut Store<HostState>,
     ) -> anyhow::Result<ConsentMapping> {
-        let instance_pre = self
-            .components
-            .consent_mapping
-            .get(id);
+        let instance_pre = self.components.consent_mapping.get(id);
 
         if instance_pre.is_none() {
             return Err(anyhow::anyhow!("component not found: {}", id));

--- a/crates/components-runtime/src/context.rs
+++ b/crates/components-runtime/src/context.rs
@@ -90,16 +90,20 @@ impl ComponentsContext {
 
     pub async fn get_data_collection_instance(
         &self,
-        name: &str,
+        id: &str,
         store: &mut Store<HostState>,
     ) -> anyhow::Result<DataCollection> {
         let instance_pre = self
             .components
             .data_collection
-            .get(name)
-            .expect("Data collection component not found");
+            .get(id);
+
+        if instance_pre.is_none() {
+            return Err(anyhow::anyhow!("component not found: {}", id));
+        }
 
         instance_pre
+            .unwrap()
             .instantiate_async(store)
             .await
             .map_err(Into::into)
@@ -107,16 +111,20 @@ impl ComponentsContext {
 
     pub async fn get_consent_mapping_instance(
         &self,
-        name: &str,
+        id: &str,
         store: &mut Store<HostState>,
     ) -> anyhow::Result<ConsentMapping> {
         let instance_pre = self
             .components
             .consent_mapping
-            .get(name)
-            .expect("Consent mapping component not found");
+            .get(id);
+
+        if instance_pre.is_none() {
+            return Err(anyhow::anyhow!("component not found: {}", id));
+        }
 
         instance_pre
+            .unwrap()
             .instantiate_async(store)
             .await
             .map_err(Into::into)

--- a/crates/components-runtime/src/context.rs
+++ b/crates/components-runtime/src/context.rs
@@ -41,18 +41,18 @@ impl ComponentsContext {
             .data_collection
             .iter()
             .map(|entry| {
-                let span = tracing::info_span!("component-context", component = %entry.name, category = "data-collection");
+                let span = tracing::info_span!("component-context", component = %entry.id, category = "data-collection");
                 let _span = span.enter();
 
                 tracing::debug!("Start pre-instantiate data collection component");
 
-                let component = Component::from_file(&engine, &entry.component)?;
+                let component = Component::from_file(&engine, &entry.file)?;
                 let instance_pre = linker.instantiate_pre(&component)?;
                 let instance_pre = DataCollectionPre::new(instance_pre)?;
 
                 tracing::debug!("Finished pre-instantiate data collection component");
 
-                Ok((entry.name.clone(), instance_pre))
+                Ok((entry.id.clone(), instance_pre))
             })
             .collect::<anyhow::Result<_>>()?;
 

--- a/crates/components-runtime/src/data_collection/debug.rs
+++ b/crates/components-runtime/src/data_collection/debug.rs
@@ -96,7 +96,7 @@ pub struct DebugParams {
 impl DebugParams {
     pub fn new(
         ctx: &EventContext,
-        component_id: &str,
+        project_component_id: &str,
         component_slug: &str,
         event: &Event,
         request: &EdgeeRequest,
@@ -106,7 +106,7 @@ impl DebugParams {
         DebugParams {
             from: ctx.get_from().clone(),
             project_id: ctx.get_project_id().clone(),
-            component_id: component_id.to_string(),
+            component_id: project_component_id.to_string(),
             component_slug: component_slug.to_string(),
             event: event.clone(),
             request: request.clone(),

--- a/crates/components-runtime/src/data_collection/mod.rs
+++ b/crates/components-runtime/src/data_collection/mod.rs
@@ -143,7 +143,10 @@ pub async fn send_events(
             }
 
             // get the instance of the component
-            let instance = match component_ctx.get_data_collection_instance(&cfg.id, &mut store).await {
+            let instance = match component_ctx
+                .get_data_collection_instance(&cfg.id, &mut store)
+                .await
+            {
                 Ok(instance) => instance,
                 Err(err) => {
                     error!("Failed to get data collection instance. Error: {}", err);

--- a/crates/components-runtime/src/data_collection/mod.rs
+++ b/crates/components-runtime/src/data_collection/mod.rs
@@ -201,7 +201,7 @@ pub async fn send_events(
                 headers.insert(HeaderName::from_str(key)?, HeaderValue::from_str(value)?);
             }
 
-            if cfg.forward_client_headers.unwrap_or(true) {
+            if request.forward_client_headers {
                 insert_expected_headers(&mut headers, &event, &component_event)?;
             }
 

--- a/crates/components-runtime/src/data_collection/mod.rs
+++ b/crates/components-runtime/src/data_collection/mod.rs
@@ -143,9 +143,13 @@ pub async fn send_events(
             }
 
             // get the instance of the component
-            let instance = component_ctx
-                .get_data_collection_instance(&cfg.id, &mut store)
-                .await?;
+            let instance = match component_ctx.get_data_collection_instance(&cfg.id, &mut store).await {
+                Ok(instance) => instance,
+                Err(err) => {
+                    error!("Failed to get data collection instance. Error: {}", err);
+                    continue;
+                }
+            };
             let component = instance.edgee_protocols_data_collection();
 
             let component_event: Component::Event = event.clone().into();

--- a/crates/components-runtime/src/data_collection/payload.rs
+++ b/crates/components-runtime/src/data_collection/payload.rs
@@ -92,57 +92,16 @@ impl Event {
             return &true;
         }
 
+        let components = self.components.as_ref().unwrap();
+
         // get destinations.get("all")
-        let all = self
-            .components
-            .as_ref()
-            .unwrap()
-            .get("all")
-            .unwrap_or(&true);
+        let all = components.get("all").unwrap_or(&true);
 
-        // check if the components is enabled by id
-        if self
-            .components
-            .as_ref()
-            .unwrap()
-            .contains_key(config.id.as_str())
-        {
-            return self
-                .components
-                .as_ref()
-                .unwrap()
-                .get(config.id.as_str())
-                .unwrap();
-        }
-
-        // check if the components is enabled by project_component_id
-        if self
-            .components
-            .as_ref()
-            .unwrap()
-            .contains_key(config.project_component_id.as_str())
-        {
-            return self
-                .components
-                .as_ref()
-                .unwrap()
-                .get(config.project_component_id.as_str())
-                .unwrap();
-        }
-
-        // check if the components is enabled by slug
-        if self
-            .components
-            .as_ref()
-            .unwrap()
-            .contains_key(config.slug.as_str())
-        {
-            return self
-                .components
-                .as_ref()
-                .unwrap()
-                .get(config.slug.as_str())
-                .unwrap();
+        // Check each possible key in order of priority
+        for key in [&config.id, &config.project_component_id, &config.slug] {
+            if let Some(enabled) = components.get(key.as_str()) {
+                return enabled;
+            }
         }
 
         all

--- a/crates/components-runtime/src/data_collection/payload.rs
+++ b/crates/components-runtime/src/data_collection/payload.rs
@@ -4,6 +4,8 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt;
 
+use crate::config::DataCollectionComponents;
+
 pub type Dict = HashMap<String, serde_json::Value>;
 
 #[derive(Serialize, Debug, Clone, Default)]
@@ -84,7 +86,7 @@ impl<'de> Deserialize<'de> for Event {
 }
 
 impl Event {
-    pub fn is_component_enabled(&self, name: &str) -> &bool {
+    pub fn is_component_enabled(&self, config: &DataCollectionComponents) -> &bool {
         // if destinations is not set, return true
         if self.components.is_none() {
             return &true;
@@ -98,10 +100,51 @@ impl Event {
             .get("all")
             .unwrap_or(&true);
 
-        // check if the components is enabled
-        if self.components.as_ref().unwrap().contains_key(name) {
-            return self.components.as_ref().unwrap().get(name).unwrap();
+        // check if the components is enabled by id
+        if self
+            .components
+            .as_ref()
+            .unwrap()
+            .contains_key(config.id.as_str())
+        {
+            return self
+                .components
+                .as_ref()
+                .unwrap()
+                .get(config.id.as_str())
+                .unwrap();
         }
+
+        // check if the components is enabled by project_component_id
+        if self
+            .components
+            .as_ref()
+            .unwrap()
+            .contains_key(config.project_component_id.as_str())
+        {
+            return self
+                .components
+                .as_ref()
+                .unwrap()
+                .get(config.project_component_id.as_str())
+                .unwrap();
+        }
+
+        // check if the components is enabled by slug
+        if self
+            .components
+            .as_ref()
+            .unwrap()
+            .contains_key(config.slug.as_str())
+        {
+            return self
+                .components
+                .as_ref()
+                .unwrap()
+                .get(config.slug.as_str())
+                .unwrap();
+        }
+
         all
     }
 }

--- a/crates/components-runtime/wit/deps.lock
+++ b/crates/components-runtime/wit/deps.lock
@@ -1,4 +1,4 @@
 [protocols]
-url = "https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.3.0.tar.gz"
-sha256 = "4d412367fff6f826280acbe95f7067e362d9299d76e60994981e7e27c74d1576"
-sha512 = "65021cace5ed07990fdfb563699accb975a31cb22311739ff6189849b969b06b564a0f8f72de154fd086ba474757d3cffaef0175778e4989c467280cf1c86284"
+url = "https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.4.0.tar.gz"
+sha256 = "8b5c8ea97c81d1d6cf4f227e75afb8c4dc5c0a411c3a0401fb7e4f7b745e21ba"
+sha512 = "16771cd12095409e7c4857a8f5c0b4ad680959e3c35dcd7999e11131bcce05d3b1a1b829daefceabbd853ae5b7f6453e3e359ddfbdebd6e2a94db6c55780368f"

--- a/crates/components-runtime/wit/deps.toml
+++ b/crates/components-runtime/wit/deps.toml
@@ -1,1 +1,1 @@
-protocols="https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.3.0.tar.gz"
+protocols="https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.4.0.tar.gz"

--- a/crates/components-runtime/wit/deps/protocols/consent-mapping.wit
+++ b/crates/components-runtime/wit/deps/protocols/consent-mapping.wit
@@ -1,7 +1,7 @@
 package edgee:protocols;
 
 interface consent-mapping {
-    type config = list<tuple<string,string>>;
+    type dict = list<tuple<string,string>>;
 
     enum consent {
         pending,
@@ -9,5 +9,5 @@ interface consent-mapping {
         denied,
     }
 
-    map: func(cookie: string, config: config) -> option<consent>;
+    map: func(cookie: string, settings: dict) -> option<consent>;
 }

--- a/crates/components-runtime/wit/deps/protocols/data-collection.wit
+++ b/crates/components-runtime/wit/deps/protocols/data-collection.wit
@@ -102,12 +102,13 @@ interface data-collection {
         method: http-method,
         url: string,
         headers: dict,
+        forward-client-headers: bool,
         body: string,
     }
 
     enum http-method { GET, PUT, POST, DELETE }
 
-    page: func(e: event, cred: dict) -> result<edgee-request, string>;
-    track: func(e: event, cred: dict) -> result<edgee-request, string>;
-    user: func(e: event, cred:dict) -> result<edgee-request, string>;
+    page: func(e: event, settings: dict) -> result<edgee-request, string>;
+    track: func(e: event, settings: dict) -> result<edgee-request, string>;
+    user: func(e: event, settings:dict) -> result<edgee-request, string>;
 }

--- a/crates/server/src/proxy/compute/data_collection/mod.rs
+++ b/crates/server/src/proxy/compute/data_collection/mod.rs
@@ -14,7 +14,7 @@ use http::{header, HeaderMap};
 use json_comments::StripComments;
 use payload::{Consent, EventData, EventType, Payload};
 use regex::Regex;
-use tracing::{info, warn, Instrument};
+use tracing::{info, error, warn, Instrument};
 
 use crate::proxy::compute::html::Document;
 use crate::proxy::context::incoming::RequestHandle;
@@ -177,7 +177,7 @@ pub async fn process_from_html(
             )
             .await
             {
-                warn!(?err, "failed to send data collection payload");
+                error!("Failed to use data collection components. Error: {}", err);
             }
         }
         .in_current_span(),
@@ -313,7 +313,7 @@ pub async fn process_from_json(
             )
             .await
             {
-                warn!(?err, "failed to send data collection payload");
+                error!("Failed to use data collection components. Error: {}", err);
             }
         }
         .in_current_span(),

--- a/crates/server/src/proxy/compute/data_collection/mod.rs
+++ b/crates/server/src/proxy/compute/data_collection/mod.rs
@@ -14,7 +14,7 @@ use http::{header, HeaderMap};
 use json_comments::StripComments;
 use payload::{Consent, EventData, EventType, Payload};
 use regex::Regex;
-use tracing::{info, error, warn, Instrument};
+use tracing::{error, info, warn, Instrument};
 
 use crate::proxy::compute::html::Document;
 use crate::proxy::context::incoming::RequestHandle;

--- a/edgee.sample.toml
+++ b/edgee.sample.toml
@@ -18,20 +18,20 @@ proxy_only = false
 enforce_no_store_policy = true
 
 [[components.data_collection]]
-name = "amplitude"
-component = "local/wasm/amplitude.wasm"
-credentials.amplitude_api_key = "..."
+id = "amplitude"
+file = "local/wasm/amplitude.wasm"
+settings.amplitude_api_key = "..."
 
 [[components.data_collection]]
-name = "google analytics"
-component = "local/wasm/ga.wasm"
-credentials.ga_measurement_id = "..."
+id = "google analytics"
+file = "local/wasm/ga.wasm"
+settings.ga_measurement_id = "..."
 
 [[components.data_collection]]
-name = "segment"
-component = "local/wasm/segment.wasm"
-credentials.segment_project_id = "..."
-credentials.segment_write_key = "..."
+id = "segment"
+file = "local/wasm/segment.wasm"
+settings.segment_project_id = "..."
+settings.segment_write_key = "..."
 
 [[routing]]
 domain = "demo.edgee.dev"


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This pull request introduces changes to DataCollectionComponents configuration fields. 
- `name` becomes `id`
- `component` becomes `file`
- `credentials` and `config` are merged into `settings`
- `forward_client_headers` is removed (it is now a part of the `edgee_request` object return by components)

These changes affect edgee.toml components part:

```toml
[[components.data_collection]]
id = "amplitude" # could be a slug (edgee/amplitude) or an alias (amplitude)
file = "../components/amplitude-component/amplitude.wasm"
settings.amplitude_api_key = "xxxx"
settings.edgee_anonymization = true
settings.edgee_default_consent = "pending"
settings.edgee_track_event_enabled = false
settings.edgee_user_event_enabled = true
settings.edgee_page_event_enabled = true
```

##### Other changes:
- New wit protocol (with `forward_client_headers`)
- Openapi.json fixes
- Readme changes following the new component configuration


### Related Issues

List related issues here
