### PR TITLE
Update Link with Tidle Prefix

### DIFF
--- a/crates/cli/src/commands/auth/login.rs
+++ b/crates/cli/src/commands/auth/login.rs
@@ -15,7 +15,7 @@ pub async fn run(_opts: Options) {
     }
 
     let api_token = Password::new("Enter Edgee API token (press Ctrl+R to toggle input display):")
-        .with_help_message("You can create one at https://www.edgee.cloud/me/settings/tokens")
+        .with_help_message("You can create one at https://www.edgee.cloud/~/me/settings/tokens")
         .with_display_mode(PasswordDisplayMode::Masked)
         .with_display_toggle_enabled()
         .without_confirmation()


### PR DESCRIPTION
This PR introduces an update of the Console links in order to add missing Tildes.