### PR TITLE
component test: inherit stdout from host

### DIFF
--- a/crates/cli/src/commands/components/test.rs
+++ b/crates/cli/src/commands/components/test.rs
@@ -66,7 +66,7 @@ async fn test_data_collection_component(opts: Options) -> anyhow::Result<()> {
     let context = ComponentsContext::new(&config)
         .map_err(|_e| anyhow::anyhow!("Something went wrong when trying to load the Wasm file. Please re-build and try again."))?;
 
-    let mut store = context.empty_store();
+    let mut store = context.empty_store_with_stdout();
 
     let instance = context
         .get_data_collection_instance(&component_path, &mut store)

--- a/crates/components-runtime/src/context.rs
+++ b/crates/components-runtime/src/context.rs
@@ -174,18 +174,15 @@ pub struct HostState {
 
 impl HostState {
     fn new() -> Self {
-        let ctx = WasiCtx::builder().build();
-
-        let table = ResourceTable::new();
-
-        Self { ctx, table }
+        Self::new_with_ctx(WasiCtx::builder().build())
     }
 
     fn new_with_stdout() -> Self {
-        let ctx = WasiCtx::builder().inherit_stdout().build();
+        Self::new_with_ctx(WasiCtx::builder().inherit_stdout().build())
+    }
 
+    fn new_with_ctx(ctx: WasiCtx) -> Self {
         let table = ResourceTable::new();
-
         Self { ctx, table }
     }
 }

--- a/crates/components-runtime/src/context.rs
+++ b/crates/components-runtime/src/context.rs
@@ -126,6 +126,10 @@ impl ComponentsContext {
         Store::new(&self.engine, HostState::new())
     }
 
+    pub fn empty_store_with_stdout(&self) -> Store<HostState> {
+        Store::new(&self.engine, HostState::new_with_stdout())
+    }
+
     pub async fn get_data_collection_instance(
         &self,
         id: &str,
@@ -171,6 +175,14 @@ pub struct HostState {
 impl HostState {
     fn new() -> Self {
         let ctx = WasiCtx::builder().build();
+
+        let table = ResourceTable::new();
+
+        Self { ctx, table }
+    }
+
+    fn new_with_stdout() -> Self {
+        let ctx = WasiCtx::builder().inherit_stdout().build();
 
         let table = ResourceTable::new();
 


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

When a component is ran through `edgee component test`, stdout of the component will be the one of the host
```
╰─$ ../../../edgee/target/release/edgee components test  --event-type page                                                                                                                                            
---------------------------------------------------
Calling page
hello from python wasm guest
```