### PR TITLE
Fix: test command accepts setting values with a '=' character

### DIFF
--- a/crates/cli/src/commands/components/test.rs
+++ b/crates/cli/src/commands/components/test.rs
@@ -25,7 +25,7 @@ fn parse_settings(settings_str: &str) -> Result<HashMap<String, String>, String>
     let mut settings_map = HashMap::new();
 
     for setting in settings_str.split(',') {
-        let parts: Vec<&str> = setting.split('=').collect();
+        let parts: Vec<&str> = setting.splitn(2, '=').collect();
         if parts.len() == 2 {
             settings_map.insert(parts[0].to_string(), parts[1].to_string());
         } else {


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](https://github.com/edgee-cloud/.github/blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](https://github.com/edgee-cloud/.github/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The test command would break if you passed a setting value with a `=` character in it (which is quite common with base64-encoded strings).
