### PR TITLE
feat: no more moving path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
+checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
+checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1209,21 +1209,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "edgee-path"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27186522959c93bb0679c2cf3b3e982321673761d7947ce891bfab39ca6c0fe"
-dependencies = [
- "rand",
-]
-
-[[package]]
 name = "edgee-sdk"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76d9922daff359069fad59a307a77921bc543bab14dff7be2b7e94bae95320c"
+checksum = "7d0f50b99eaa06c2edbf07e7e996d1c3a9e31172438e51f265f65c0855189f0a"
 dependencies = [
- "edgee-path",
+ "md5",
 ]
 
 [[package]]
@@ -1240,7 +1231,6 @@ dependencies = [
  "chrono",
  "cookie",
  "edgee-components-runtime",
- "edgee-path",
  "edgee-sdk",
  "futures",
  "hex",
@@ -2290,6 +2280,12 @@ name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -3645,9 +3641,9 @@ checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"
-version = "3.17.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40f762a77d2afa88c2d919489e390a12bdd261ed568e60cfa7e48d4e20f0d33"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -4011,9 +4007,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "typify"
@@ -4148,9 +4144,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+checksum = "8c1f41ffb7cf259f1ecc2876861a17e7142e63ead296f671f81f6ae85903e0d6"
 dependencies = [
  "getrandom 0.3.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,7 @@ zip = "2.2.2"
 cargo-llvm-cov = "0.6.15"
 pretty_assertions = "1.4.1"
 
-edgee-sdk = "1.3.2"
-edgee-path = "0.1.1"
+edgee-sdk = "1.5.0"
 
 edgee-api-client = { version = "0.8.0", path = "crates/api-client" }
 edgee-server = { version = "0.8.0", path = "crates/server" }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -47,7 +47,6 @@ tracing.workspace = true
 url.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
 
-edgee-path.workspace = true
 edgee-sdk.workspace = true
 edgee-components-runtime.workspace = true
 

--- a/crates/server/src/proxy/compute/html.rs
+++ b/crates/server/src/proxy/compute/html.rs
@@ -168,7 +168,7 @@ pub fn parse_html(html: &str, host: &str) -> Document {
 
                         // if inline is true, then we need to inline the SDK
                         if let (true, Some(sdk_url)) = (inline, &builder.sdk_src) {
-                            if let Ok(inlined_sdk) = edgee_sdk::get_sdk_from_url(sdk_url, host) {
+                            if let Ok(inlined_sdk) = edgee_sdk::get_sdk(sdk_url, host) {
                                 set_document_field!(builder, inlined_sdk, inlined_sdk);
                             }
                         }


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](https://github.com/edgee-cloud/.github/blob/main/CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](https://github.com/edgee-cloud/.github/blob/main/CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Event paths rotated with each page view. The idea was interesting, but it added complexity to the SEO management of these URLs. 
In the end, we use the current url to collect an event, which makes data collection even more efficient.

For this, the sdk is bumped to version 5, and we no longer need the edge-path crate.

### Related Issues

No issue related
