### PR TITLE
Update component name on push (requires API release)

### DIFF
--- a/crates/api-client/openapi.json
+++ b/crates/api-client/openapi.json
@@ -3514,6 +3514,10 @@
             "description": "Link to the repository of the component.",
             "format": "url"
           },
+          "name": {
+            "type": "string",
+            "description": "Name of the component."
+          },
           "description": {
             "type": "string",
             "description": "Description of the component."

--- a/crates/cli/src/commands/components/push.rs
+++ b/crates/cli/src/commands/components/push.rs
@@ -223,6 +223,7 @@ pub async fn run(opts: Options) -> anyhow::Result<()> {
             .component_slug(&component_slug)
             .body(
                 api_types::ComponentUpdateParams::builder()
+                    .name(manifest.component.name)
                     .description(manifest.component.description.clone())
                     .public(component.is_public)
                     .documentation_link(

--- a/crates/cli/src/commands/components/push.rs
+++ b/crates/cli/src/commands/components/push.rs
@@ -223,7 +223,7 @@ pub async fn run(opts: Options) -> anyhow::Result<()> {
             .component_slug(&component_slug)
             .body(
                 api_types::ComponentUpdateParams::builder()
-                    .name(manifest.component.name)
+                    .name(manifest.component.name.clone())
                     .description(manifest.component.description.clone())
                     .public(component.is_public)
                     .documentation_link(


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](https://github.com/edgee-cloud/.github/blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](https://github.com/edgee-cloud/.github/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This updates the component name via API on `edgee component push`.

We need to add the input parameter on the API side too.
