### PR TITLE
openapi.json: user slug is not provided anymore

### DIFF
--- a/crates/api-client/openapi.json
+++ b/crates/api-client/openapi.json
@@ -3667,11 +3667,6 @@
             "description": "Name of the user",
             "readOnly": true
           },
-          "slug": {
-            "type": "string",
-            "description": "Slug of the user",
-            "readOnly": true
-          },
           "avatar_url": {
             "type": "string",
             "description": "Avatar of the user",
@@ -3697,7 +3692,6 @@
           "id",
           "email",
           "name",
-          "slug",
           "role",
           "created_at",
           "updated_at"


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](https://github.com/edgee-cloud/.github/blob/main/CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](https://github.com/edgee-cloud/.github/blob/main/CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

/v1/users/me does not return a slug anymore
