### PR TITLE
fix: abort compute if sec-fetch-dest is for specific content

### DIFF
--- a/crates/server/src/proxy/compute/mod.rs
+++ b/crates/server/src/proxy/compute/mod.rs
@@ -126,6 +126,19 @@ fn do_process_payload(request: &RequestHandle, response: &mut Parts) -> Result<b
         Err("compute-aborted(prefetch)")?;
     }
 
+    // do not process the payload if the request is made for specific fetch destination
+    let set_fetch_dest = request
+        .get_header("sec-fetch-dest")
+        .unwrap_or("".to_string());
+    if !set_fetch_dest.is_empty() {
+        let forbidden_fetch_dest = [
+            "audio", "font", "image", "manifest", "script", "style", "video",
+        ];
+        if forbidden_fetch_dest.contains(&set_fetch_dest.as_str()) {
+            Err("compute-aborted(fetch-dest)")?;
+        }
+    }
+
     Ok(true)
 }
 


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](https://github.com/edgee-cloud/.github/blob/main/CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](https://github.com/edgee-cloud/.github/blob/main/CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

When a page URL is unfortunately added in a <img> tag, Edgee processes it as a standard request that has to be computed. 
I added a new check in `do_process_payload` function, to look at the `sec-fetch-dest` request header. If this header tells the request has been made to get a specific kind of content (e.g an image), the computation is aborted.

### Related Issues

No issue
