### PR TITLE
feat(ci): add homebrew GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,12 @@ jobs:
         with:
           file: edgee.${{ matrix.platform.target }}${{ matrix.platform.bin_suffix || '' }}
           tags: true
+
+  homebrew-pull-request:
+    name: Create new PR for Homebrew
+    needs: build-release-binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: edgee-cloud/homebrew-edgee@v0.1.0
+        with:
+          ACTION_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description of Changes

Use the new GitHub Action defined in https://github.com/edgee-cloud/homebrew-edgee to create a PR automatically on release.

