### PR TITLE
feat(security): add 'empty' to forbidden fetch destinations

### DIFF
--- a/crates/server/src/proxy/compute/mod.rs
+++ b/crates/server/src/proxy/compute/mod.rs
@@ -132,7 +132,7 @@ fn do_process_payload(request: &RequestHandle, response: &mut Parts) -> Result<b
         .unwrap_or("".to_string());
     if !set_fetch_dest.is_empty() {
         let forbidden_fetch_dest = [
-            "audio", "font", "image", "manifest", "script", "style", "video",
+            "audio", "font", "image", "manifest", "script", "style", "video", "empty",
         ];
         if forbidden_fetch_dest.contains(&set_fetch_dest.as_str()) {
             Err("compute-aborted(fetch-dest)")?;


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](https://github.com/edgee-cloud/.github/blob/main/CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](https://github.com/edgee-cloud/.github/blob/main/CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

## Description
This PR adds 'empty' to the list of forbidden fetch destinations in the `do_process_payload` function. This change prevents the processing of requests that have an empty fetch destination, which could potentially be used for malicious purposes or cause unnecessary processing overhead.

## Changes
- Added 'empty' to the list of forbidden fetch destinations in `fastly-edgee/src/proxy/compute/mod.rs`

## Security Impact
This change improves security by preventing potential abuse through empty fetch destinations.

### Related Issues

List related issues here
