### PR TITLE
ci: remove homebrew workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,3 @@ jobs:
         with:
           file: edgee.${{ matrix.platform.target }}${{ matrix.platform.bin_suffix || '' }}
           tags: true
-
-  homebrew-pull-request:
-    name: Run workflow in homebrew-edgee repo to create new release PR
-    needs: build-release-binaries
-    runs-on: ubuntu-latest
-    steps:
-      - run: gh workflow run new-release-pr.yml -R edgee-cloud/homebrew-edgee
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Context: you can't use the default GITHUB_TOKEN to trigger workflows (or anything else) in another repository. That requires using a personal access token with expanded scope. Imho, not worth messing with for now.

We can just trigger the homebrew workflow manually from here after each release: https://github.com/edgee-cloud/homebrew-edgee/actions/workflows/new-release-pr.yml