### PR TITLE
ci(release): upload Debug Information Files to Sentry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,16 @@ jobs:
         with:
           file: edgee.${{ matrix.platform.target }}${{ matrix.platform.bin_suffix || '' }}
           tags: true
+
+      - name: Install Sentry CLI
+        uses: matbour/setup-sentry-cli@v2
+        with:
+          version: latest
+          token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          organization: ${{ vars.SENTRY_ORG }}
+          project: ${{ vars.SENTRY_PROJECT }}
+
+      - name: Upload Debug Information Files to Sentry
+        run: |
+          sentry-cli debug-files bundle-sources target/${{ matrix.platform.target }}/debug/edgee
+          sentry-cli debug-files upload target/${{ matrix.platform.target }}/debug/edgee.src.zip target/${{ matrix.platform.target }}/debug/edgee


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](https://github.com/edgee-cloud/.github/blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](https://github.com/edgee-cloud/.github/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Adds two new steps to the GitHub Actions workflow on release:
- Installs the Sentry CLI tool
- Uses Sentry CLI to upload debug information files to Sentry

The repo would need to have three new secrets and variables for the CI:
- `SENTRY_AUTH_TOKEN` secret
- `SENTRY_ORG` and `SENTRY_PROJECT` variables

### Related Issues

- Closes EDGEE-632
