### PR TITLE
ci(release): use release build for Sentry Debug Information Files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,5 +75,5 @@ jobs:
 
       - name: Upload Debug Information Files to Sentry
         run: |
-          sentry-cli debug-files bundle-sources target/${{ matrix.platform.target }}/debug/edgee
-          sentry-cli debug-files upload target/${{ matrix.platform.target }}/debug/edgee.src.zip target/${{ matrix.platform.target }}/debug/edgee
+          sentry-cli debug-files bundle-sources target/${{ matrix.platform.target }}/release/edgee
+          sentry-cli debug-files upload target/${{ matrix.platform.target }}/release/edgee.src.zip target/${{ matrix.platform.target }}/release/edgee


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](https://github.com/edgee-cloud/.github/blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](https://github.com/edgee-cloud/.github/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Use the release build when sending the debug information files to Sentry
