### PR TITLE
fix(server): don't drop error when starting the server

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -199,11 +199,4 @@ mod tests {
         let ctx = get_components_ctx();
         assert_eq!(ctx.engine.is_async(), true);
     }
-
-    #[tokio::test]
-    async fn test_start_server() {
-        init_test_config();
-        start().await.unwrap();
-        // no idea how to test this one
-    }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](https://github.com/edgee-cloud/.github/blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](https://github.com/edgee-cloud/.github/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Propagate error on server start instead of dropping it, that should help not triggering some panic in the `tokio::select!` macro usage
in the `edgee serve` command.

### Related Issues

- Fixes SENTRY-CLI-15
