### PR TITLE
Add component serialization support for faster loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,8 +1698,6 @@ dependencies = [
  "unicase",
  "url",
  "uuid",
- "wasmtime",
- "wasmtime-wasi-http",
  "wit-deps",
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,6 +1698,7 @@ dependencies = [
  "unicase",
  "url",
  "uuid",
+ "wasmtime",
  "wasmtime-wasi-http",
  "wit-deps",
  "zip",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -50,8 +50,6 @@ unicase.workspace = true
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["v4"] }
 wit-deps.workspace = true
-wasmtime-wasi-http.workspace = true
-wasmtime.workspace = true
 zip.workspace = true
 
 edgee-api-client.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -51,6 +51,7 @@ url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["v4"] }
 wit-deps.workspace = true
 wasmtime-wasi-http.workspace = true
+wasmtime.workspace = true
 zip.workspace = true
 
 edgee-api-client.workspace = true

--- a/crates/cli/src/commands/components/mod.rs
+++ b/crates/cli/src/commands/components/mod.rs
@@ -25,6 +25,9 @@ setup_commands! {
 
     /// Fetch WIT dependencies needed for building
     Wit(fetch_wit),
+
+    /// Serialize component
+    Serialize(serialize),
 }
 
 pub type Options = Command;

--- a/crates/cli/src/commands/components/mod.rs
+++ b/crates/cli/src/commands/components/mod.rs
@@ -27,6 +27,8 @@ setup_commands! {
     Wit(fetch_wit),
 
     /// Serialize component
+    /// This serializes the component to a vector of bytes.
+    /// This is a low-level operation and is not needed for most users.
     Serialize(serialize),
 }
 

--- a/crates/cli/src/commands/components/serialize.rs
+++ b/crates/cli/src/commands/components/serialize.rs
@@ -73,9 +73,11 @@ pub async fn serialize_component(
             "1.0.0" => context.serialize_edge_function_1_0_0(component_path)?,
             _ => anyhow::bail!("Invalid WIT version: {}", component_wit_version),
         },
-        _ => anyhow::bail!(
-            "Serialization is only supported for Edge Function components at the moment"
-        ),
+        ComponentType::DataCollection => match component_wit_version {
+            "1.0.0" => context.serialize_data_collection_1_0_0(component_path)?,
+            "1.0.1" => context.serialize_data_collection_1_0_1(component_path)?,
+            _ => anyhow::bail!("Invalid WIT version: {}", component_wit_version),
+        },
     };
 
     let serialized_path = format!("{}.serialized", component_path);

--- a/crates/cli/src/commands/components/serialize.rs
+++ b/crates/cli/src/commands/components/serialize.rs
@@ -80,7 +80,7 @@ pub async fn serialize_component(
         },
     };
 
-    let serialized_path = format!("{}.serialized", component_path);
+    let serialized_path = format!("{component_path}.serialized");
     match std::fs::write(&serialized_path, serialized_component) {
         Ok(_) => {
             tracing::info!("Component serialized successfully to {}", serialized_path);

--- a/crates/cli/src/commands/components/serialize.rs
+++ b/crates/cli/src/commands/components/serialize.rs
@@ -1,0 +1,155 @@
+use edgee_components_runtime::config::EdgeFunctionComponents;
+
+setup_command! {
+    #[arg(long = "filename")]
+    filename: Option<String>,
+    #[arg(long = "component-type")]
+    component_type: Option<String>,
+    #[arg(long = "wit-version")]
+    wit_version: Option<String>,
+}
+
+pub enum ComponentType {
+    DataCollection,
+    EdgeFunction,
+}
+
+pub async fn serialize_component(
+    component_type: ComponentType,
+    component_path: &str,
+    component_wit_version: &str,
+) -> anyhow::Result<()> {
+    use edgee_components_runtime::config::{ComponentsConfiguration, DataCollectionComponents};
+    use edgee_components_runtime::context::ComponentsContext;
+
+    if !std::fs::exists(component_path)? {
+        anyhow::bail!(
+            "Component {} does not exist. Please run `edgee component build` first",
+            component_path
+        );
+    }
+
+    let config = match component_type {
+        ComponentType::DataCollection => match component_wit_version {
+            "1.0.0" => ComponentsConfiguration {
+                data_collection: vec![DataCollectionComponents {
+                    id: component_path.to_string(),
+                    file: component_path.to_string(),
+                    wit_version: edgee_components_runtime::data_collection::versions::DataCollectionWitVersion::V1_0_0,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            "1.0.1" => ComponentsConfiguration {
+                data_collection: vec![DataCollectionComponents {
+                    id: component_path.to_string(),
+                    file: component_path.to_string(),
+                    wit_version: edgee_components_runtime::data_collection::versions::DataCollectionWitVersion::V1_0_1,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            _ => anyhow::bail!("Invalid WIT version: {}", component_wit_version),
+        },
+        ComponentType::EdgeFunction => match component_wit_version {
+            "1.0.0" => ComponentsConfiguration {
+                edge_function: vec![EdgeFunctionComponents{
+                    id: component_path.to_string(),
+                    file: component_path.to_string(),
+                    wit_version: edgee_components_runtime::edge_function::versions::EdgeFunctionWitVersion::V1_0_0,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            _ => anyhow::bail!("Invalid WIT version: {}", component_wit_version),
+        }
+    };
+
+    let context = ComponentsContext::new(&config)
+        .map_err(|e| anyhow::anyhow!("Invalid component {}: {}", component_path, e))?;
+
+    let serialized_component = match component_type {
+        ComponentType::EdgeFunction => match component_wit_version {
+            "1.0.0" => context.serialize_edge_function_1_0_0(component_path)?,
+            _ => anyhow::bail!("Invalid WIT version: {}", component_wit_version),
+        },
+        _ => anyhow::bail!(
+            "Serialization is only supported for Edge Function components at the moment"
+        ),
+    };
+
+    let serialized_path = format!("{}.serialized", component_path);
+    match std::fs::write(&serialized_path, serialized_component) {
+        Ok(_) => {
+            tracing::info!("Component serialized successfully to {}", serialized_path);
+        }
+        Err(err) => {
+            tracing::error!("Failed to write serialized component to file: {}", err);
+            return Err(anyhow::anyhow!(
+                "Failed to write serialized component to file: {}",
+                err
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn run(_opts: Options) -> anyhow::Result<()> {
+    use anyhow::Context;
+
+    use crate::components::manifest::{self, Manifest};
+
+    let (component_path, component_type, component_wit_version) = match (
+        _opts.filename,
+        _opts.component_type,
+        _opts.wit_version,
+    ) {
+        (Some(filename), Some(component_type), Some(version)) => match component_type.as_str() {
+            "data-collection" => (filename, ComponentType::DataCollection, version),
+            "edge-function" => (filename, ComponentType::EdgeFunction, version),
+            _ => anyhow::bail!(
+                "Invalid component type: {}, expected 'data-collection' or 'edge-function'",
+                component_type
+            ),
+        },
+        _ => {
+            let Some(manifest_path) = manifest::find_manifest_path() else {
+                anyhow::bail!("Edgee Manifest not found. Please run `edgee component new` and start from a template or `edgee component init` to create a new empty manifest in this folder.");
+            };
+
+            let manifest = Manifest::load(&manifest_path)?;
+            let component_path = manifest
+                .component
+                .build
+                .output_path
+                .to_str()
+                .context("Output path should be a valid UTF-8 string")?;
+            (
+                component_path.to_string(),
+                match manifest.component.category {
+                    edgee_api_client::types::ComponentCreateInputCategory::DataCollection => {
+                        ComponentType::DataCollection
+                    }
+                    edgee_api_client::types::ComponentCreateInputCategory::EdgeFunction => {
+                        ComponentType::EdgeFunction
+                    }
+                    _ => anyhow::bail!(
+                        "Invalid component type: {}, expected 'data-collection'",
+                        manifest.component.category
+                    ),
+                },
+                manifest.component.wit_version,
+            )
+        }
+    };
+
+    serialize_component(
+        component_type,
+        component_path.as_str(),
+        component_wit_version.as_str(),
+    )
+    .await?;
+
+    Ok(())
+}

--- a/crates/components-runtime/src/config.rs
+++ b/crates/components-runtime/src/config.rs
@@ -68,6 +68,8 @@ pub struct EdgeFunctionComponents {
     pub id: String, // could be a slug (edgee/amplitude) or an alias (amplitude)
     pub file: String,
     #[serde(default)]
+    pub serialized_file: Option<String>,
+    #[serde(default)]
     pub wit_version: EdgeFunctionWitVersion,
     #[serde(default)]
     pub settings: HashMap<String, String>,

--- a/crates/components-runtime/src/data_collection/versions/v1_0_0/mod.rs
+++ b/crates/components-runtime/src/data_collection/versions/v1_0_0/mod.rs
@@ -41,6 +41,15 @@ pub fn pre_instanciate_data_collection_component_1_0_0(
 }
 
 impl ComponentsContext {
+    pub fn serialize_data_collection_1_0_0(&self, id: &str) -> anyhow::Result<Vec<u8>> {
+        let instance_pre = self.components.data_collection_1_0_0.get(id);
+
+        match instance_pre {
+            Some(instance) => Ok(instance.instance_pre().component().serialize()?),
+            None => Err(anyhow::anyhow!("component not found: {}", id)),
+        }
+    }
+
     pub fn pre_instanciate_data_collection_1_0_0_component(
         &self,
         component_config: DataCollectionComponents,

--- a/crates/components-runtime/src/data_collection/versions/v1_0_1/mod.rs
+++ b/crates/components-runtime/src/data_collection/versions/v1_0_1/mod.rs
@@ -41,6 +41,15 @@ pub fn pre_instanciate_data_collection_component_1_0_1(
 }
 
 impl ComponentsContext {
+    pub fn serialize_data_collection_1_0_1(&self, id: &str) -> anyhow::Result<Vec<u8>> {
+        let instance_pre = self.components.data_collection_1_0_1.get(id);
+
+        match instance_pre {
+            Some(instance) => Ok(instance.instance_pre().component().serialize()?),
+            None => Err(anyhow::anyhow!("component not found: {}", id)),
+        }
+    }
+
     pub fn pre_instanciate_data_collection_1_0_1_component(
         &self,
         component_config: DataCollectionComponents,

--- a/crates/components-runtime/src/edge_function/versions/v1_0_0/mod.rs
+++ b/crates/components-runtime/src/edge_function/versions/v1_0_0/mod.rs
@@ -31,7 +31,26 @@ pub fn pre_instanciate_edge_function_component_1_0_0(
     let _span = span.enter();
 
     tracing::debug!("Start pre-instantiate edge-function component");
-    let component = Component::from_file(engine, &component_config.file)?;
+
+    // try to load from serialized file if available
+    let component = match component_config.serialized_file {
+        Some(serialized_file) => {
+            tracing::debug!(
+                "Loading edge-function component from serialized file: {}",
+                serialized_file
+            );
+            unsafe { Component::deserialize(engine, &serialized_file) }.ok()
+        }
+        None => None,
+    }
+    .unwrap_or_else(|| {
+        tracing::debug!(
+            "Loading edge-function component from file: {}",
+            component_config.file
+        );
+        Component::from_file(engine, &component_config.file)
+    })?;
+
     let instance_pre = linker.instantiate_pre(&component)?;
     let instance_pre = EdgeFunctionV100Pre::new(instance_pre)?;
     tracing::debug!("Finished pre-instantiate edge-function component");

--- a/crates/components-runtime/src/edge_function/versions/v1_0_0/mod.rs
+++ b/crates/components-runtime/src/edge_function/versions/v1_0_0/mod.rs
@@ -41,7 +41,12 @@ pub fn pre_instanciate_edge_function_component_1_0_0(
                 "Loading edge-function component from serialized file: {}",
                 serialized_file
             );
-            unsafe { Component::deserialize(engine, serialized_file) }.ok()
+            unsafe {
+                // unsafe function to deserialize the component
+                // this should only be used if the serialized file is trusted
+                Component::deserialize(engine, serialized_file)
+            }
+            .ok()
         })
         .map(Ok)
         .unwrap_or_else(|| {


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](https://github.com/edgee-cloud/.github/blob/main/CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](https://github.com/edgee-cloud/.github/blob/main/CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Add component serialization support for faster loading

Adds `edgee component serialize` command to pre-serialize WebAssembly components and unsafe deserialization support for improved startup performance.