### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,27 +21,27 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable, beta]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master branch
         with:
           toolchain: ${{ matrix.rust }}
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo build
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
@@ -56,10 +56,10 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch
         with:
           components: clippy
 
@@ -70,10 +70,10 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch
         with:
           components: rustfmt
 
@@ -84,10 +84,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch
 
       - name: Build
         run: cargo build --release --all-features
@@ -96,10 +96,10 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch
 
       - name: Check documentation
         run: cargo doc --no-deps --all-features

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: katyo/publish-crates@v2
-        with:
-          registry-token: ${{ secrets.CRATES_IO_TOKEN }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
## Summary

Addresses security audit finding f66f3510 (high severity): `publish.yml` used unpinned third-party actions — `dtolnay/rust-toolchain@stable` and `katyo/publish-crates@v2` — that could exfiltrate `CRATES_IO_TOKEN` if an upstream maintainer account or tag is compromised.

- Pin every `uses:` across `check.yml` and `publish.yml` to a commit SHA, with a trailing `# version` comment for readability.
- Replace `katyo/publish-crates@v2` with a direct `cargo publish` step (repo is a single crate, not a workspace — no publish ordering needed). Token is passed via `CARGO_REGISTRY_TOKEN` env var so it never reaches argv.

### Pins

| Action | Pin |
|---|---|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1) |
| `actions/cache` | `0057852bfaa89a56745cba8c7296529d2fc39830` (v4.3.0) |
| `dtolnay/rust-toolchain` master | `3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9` |
| `dtolnay/rust-toolchain` stable | `29eef336d9b2848a0b548edc03f92a220660cdb8` |
| `katyo/publish-crates@v2` | removed — replaced with `cargo publish` |

## Test plan

- [ ] `check.yml` runs on this PR and all matrix jobs (test/clippy/fmt/build/docs across Linux/macOS/Windows, stable+beta) pass — this exercises every pinned action.
- [ ] Manually grep the diff for unpinned refs: `grep -nE 'uses:.*@(v[0-9]\|stable\|master\|main\|beta\|nightly)\s*$' .github/workflows/*.yml` → no matches.
- [ ] `publish.yml` can only be validated on the next real release. Risk is bounded — a failed publish doesn't leak anything and is fixable forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)