### PR TITLE
chore: remove agentic compressor support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "edgee"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgee"
-version = "2.0.5"
+version = "2.0.6"
 edition = "2021"
 authors = ["Edgee <opensource@edgee.ai>"]
 license = "Apache-2.0"

--- a/examples/compression.rs
+++ b/examples/compression.rs
@@ -81,8 +81,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Create input with compression settings using builder pattern
-    let input = InputObject::new(vec![Message::user(user_message)])
-        .with_compression_model("claude");
+    let input =
+        InputObject::new(vec![Message::user(user_message)]).with_compression_model("claude");
 
     let response = client.send("anthropic/claude-haiku-4-5", input).await?;
 

--- a/examples/compression.rs
+++ b/examples/compression.rs
@@ -9,7 +9,7 @@
 //! This example includes a large context in the user message to demonstrate meaningful
 //! compression savings.
 
-use edgee::{CompressionConfiguration, Edgee, InputObject, Message};
+use edgee::{Edgee, InputObject, Message};
 
 // Large context document to demonstrate input compression
 const LARGE_CONTEXT: &str = r#"
@@ -82,11 +82,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create input with compression settings using builder pattern
     let input = InputObject::new(vec![Message::user(user_message)])
-        .with_compression_model("agentic")
-        .with_compression_configuration(CompressionConfiguration {
-            rate: Some(0.5),
-            semantic_preservation_threshold: None,
-        });
+        .with_compression_model("claude");
 
     let response = client.send("anthropic/claude-haiku-4-5", input).await?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -48,7 +48,6 @@ struct ParsedInput {
     tool_choice: Option<serde_json::Value>,
     tags: Option<Vec<String>>,
     compression_model: Option<String>,
-    compression_configuration: Option<CompressionConfiguration>,
 }
 
 /// Main client for interacting with the Edgee AI Gateway
@@ -121,9 +120,6 @@ impl Edgee {
         }
         if let Some(compression_model) = &parsed.compression_model {
             body["compression_model"] = json!(compression_model);
-        }
-        if let Some(config) = &parsed.compression_configuration {
-            body["compression_configuration"] = json!(config);
         }
 
         let response = self
@@ -200,9 +196,6 @@ impl Edgee {
         }
         if let Some(compression_model) = &parsed.compression_model {
             body["compression_model"] = json!(compression_model);
-        }
-        if let Some(config) = &parsed.compression_configuration {
-            body["compression_configuration"] = json!(config);
         }
 
         let response = self
@@ -285,7 +278,6 @@ impl Edgee {
                 tool_choice: None,
                 tags: None,
                 compression_model: None,
-                compression_configuration: None,
             },
             Input::Object(obj) => ParsedInput {
                 messages: obj.messages,
@@ -293,7 +285,6 @@ impl Edgee {
                 tool_choice: obj.tool_choice,
                 tags: obj.tags,
                 compression_model: obj.compression_model,
-                compression_configuration: obj.compression_configuration,
             },
         }
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -183,18 +183,6 @@ pub enum ToolChoice {
     },
 }
 
-/// Configuration for the compression model.
-/// Only relevant for the `agentic` compression model.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CompressionConfiguration {
-    /// Compression rate (0.0-1.0). Defaults to 0.8 when not specified.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub rate: Option<f64>,
-    /// Semantic preservation threshold (0-100).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub semantic_preservation_threshold: Option<i32>,
-}
-
 /// Input for the chat completion request
 #[derive(Debug, Clone, Serialize)]
 pub struct InputObject {
@@ -205,16 +193,11 @@ pub struct InputObject {
     pub tool_choice: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
-    /// Compression model for this request (agentic, claude, opencode, cursor, or customer).
+    /// Compression model for this request (claude, opencode, cursor, or customer).
     /// Only one compression model per request. Each model is a bundle of strategies.
     /// This is a gateway-internal field and is never sent to providers.
     #[serde(default, skip_serializing)]
     pub compression_model: Option<String>,
-    /// Configuration for the compression model (rate, semantic preservation threshold).
-    /// Only relevant for the `agentic` compression model.
-    /// This is a gateway-internal field and is never sent to providers.
-    #[serde(default, skip_serializing)]
-    pub compression_configuration: Option<CompressionConfiguration>,
 }
 
 impl InputObject {
@@ -226,7 +209,6 @@ impl InputObject {
             tool_choice: None,
             tags: None,
             compression_model: None,
-            compression_configuration: None,
         }
     }
 
@@ -248,15 +230,9 @@ impl InputObject {
         self
     }
 
-    /// Set the compression model for this request (agentic, claude, opencode, cursor, customer)
+    /// Set the compression model for this request (claude, opencode, cursor, customer)
     pub fn with_compression_model(mut self, model: impl Into<String>) -> Self {
         self.compression_model = Some(model.into());
-        self
-    }
-
-    /// Set the compression configuration (only relevant for agentic model)
-    pub fn with_compression_configuration(mut self, config: CompressionConfiguration) -> Self {
-        self.compression_configuration = Some(config);
         self
     }
 }
@@ -438,15 +414,8 @@ mod tests {
     #[test]
     fn test_input_object_with_compression_builder() {
         let input = InputObject::new(vec![Message::user("Hello")])
-            .with_compression_model("agentic")
-            .with_compression_configuration(CompressionConfiguration {
-                rate: Some(0.5),
-                semantic_preservation_threshold: Some(60),
-            });
+            .with_compression_model("claude");
 
-        assert_eq!(input.compression_model, Some("agentic".to_string()));
-        let config = input.compression_configuration.unwrap();
-        assert_eq!(config.rate, Some(0.5));
-        assert_eq!(config.semantic_preservation_threshold, Some(60));
+        assert_eq!(input.compression_model, Some("claude".to_string()));
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -413,8 +413,7 @@ mod tests {
 
     #[test]
     fn test_input_object_with_compression_builder() {
-        let input = InputObject::new(vec![Message::user("Hello")])
-            .with_compression_model("claude");
+        let input = InputObject::new(vec![Message::user("Hello")]).with_compression_model("claude");
 
         assert_eq!(input.compression_model, Some("claude".to_string()));
     }


### PR DESCRIPTION
## Summary
- Drop the `agentic` compression model from the SDK now that the gateway no longer offers it
- Remove the `CompressionConfiguration` struct, the `compression_configuration` field on `InputObject`/`ParsedInput`, the `with_compression_configuration` builder, and the body-serialization paths in `send`/`stream`
- Update the `compression.rs` example and the builder test to use the `claude` compression model and refresh the doc comments to list only the still-supported models (`claude`, `opencode`, `cursor`, `customer`)

## Test plan
- [x] `cargo build`
- [x] `cargo test` (8 unit + 5 doc tests passing)
- [ ] Confirm no downstream consumer still relies on `with_compression_configuration` / `CompressionConfiguration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)