### PR TITLE
chore(deps): bump vulnerable transitive deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -699,15 +699,14 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -731,9 +730,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -832,9 +831,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -991,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
Bumps four transitive crates in `Cargo.lock` to clear all 13 open Dependabot alerts on `main`. `Cargo.toml` already allows these versions, so no manifest changes are needed.

| Crate | From | To | Alerts |
|---|---|---|---|
| `bytes` | 1.11.0 | 1.11.1 | #20 (BytesMut::reserve integer overflow) |
| `openssl` | 0.10.75 | 0.10.80 | #27–#35 (AES KW OOB writes/heap overflow, X509 OCSP UB, Deriver short-buffer overflow, PSK/cookie trampoline leak, MdCtxRef::digest_final OOB, PEM cb OOB read) |
| `openssl-sys` | 0.9.111 | 0.9.116 | (pulled in with `openssl`) |
| `rand` | 0.9.2 | 0.9.4 | #26 (custom logger unsoundness) |
| `rustls-webpki` | 0.103.8 | 0.103.13 | #22, #24, #25, #32 (CRL DoS, name-constraint handling, CRL distribution-point matching) |

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — 8 unit + 5 doc tests passing
- [ ] Confirm Dependabot closes the listed alerts after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)